### PR TITLE
Handle ClowdApp dependencies

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -166,16 +166,29 @@ def _reset(namespace):
     multiple=True,
 )
 @click.option(
+    "--get-dependencies",
+    "-d",
+    help="Get config for any listed 'dependencies' in this app's ClowdApps",
+    is_flag=True,
+    default=False,
+)
+@click.option(
     "--namespace",
     "-n",
     help="Namespace you intend to deploy these components into",
 )
-def get_config(app, src_env, ref_env, set_template_ref, set_image_tag, namespace):
+def get_config(app, src_env, ref_env, set_template_ref, set_image_tag, get_dependencies, namespace):
     """Get kubernetes config for an app"""
     template_ref_overrides = _split_equals(set_template_ref)
     image_tag_overrides = _split_equals(set_image_tag)
     app_config = get_app_config(
-        app, src_env, ref_env, template_ref_overrides, image_tag_overrides, namespace
+        app,
+        src_env,
+        ref_env,
+        template_ref_overrides,
+        image_tag_overrides,
+        get_dependencies,
+        namespace,
     )
     print(json.dumps(app_config, indent=2))
 

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -479,7 +479,7 @@ def copy_namespace_secrets(src_namespace, dst_namespace, secret_names):
 
 
 def process_template(template_data, params):
-    valid_pnames = set(p["name"] for p in template_data["parameters"])
+    valid_pnames = set(p["name"] for p in template_data.get("parameters", []))
     param_str = " ".join(f"-p {k}={v}" for k, v in params.items() if k in valid_pnames)
 
     proc = Popen(


### PR DESCRIPTION
When running `bonfire config get` for an `app`, you can now specify the flag `--get-dependencies`. This will do the following:

* After downloading templates for `app`, it checks for any `ClowdApp` resources
* If a `ClowdApp` has dependencies listed under `spec.dependencies`, we will recursively run `bonfire config get` on the dependent app.
* This process handles nested dependencies (e.g. `app A` depends on `app B` which depends on `app C`)
* We maintain a running list of which apps we have processed so that we do not load config for the same dependency twice.