### PR TITLE
Exit on timeout expiration

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -116,8 +116,7 @@ def wait_on_resources(namespace, timeout):
     """Wait for rolled out resources to be ready in namespace"""
     ready = wait_for_all_resources(namespace, timeout)
     if not ready:
-        click.echo("Waiting for resources exeeded timeout")
-        sys.exit(1)
+        _error("Timed out waiting for resources")
 
 
 @namespace.command("prepare")

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -114,7 +114,7 @@ def _split_equals(list_of_str):
 )
 def wait_on_resources(namespace, timeout):
     """Wait for rolled out resources to be ready in namespace"""
-    ready = wait_for_all_resources(namespace, timeout):
+    ready = wait_for_all_resources(namespace, timeout)
     if not ready:
         click.echo("Waiting for resources exeeded timeout")
         sys.exit(1)

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -114,7 +114,10 @@ def _split_equals(list_of_str):
 )
 def wait_on_resources(namespace, timeout):
     """Wait for rolled out resources to be ready in namespace"""
-    wait_for_all_resources(namespace, timeout)
+    ready = wait_for_all_resources(namespace, timeout):
+    if not ready:
+        click.echo("Waiting for resources exeeded timeout")
+        sys.exit(1)
 
 
 @namespace.command("prepare")

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -114,8 +114,8 @@ def _split_equals(list_of_str):
 )
 def wait_on_resources(namespace, timeout):
     """Wait for rolled out resources to be ready in namespace"""
-    ready = wait_for_all_resources(namespace, timeout)
-    if not ready:
+    time_taken = wait_for_all_resources(namespace, timeout)
+    if time_taken >= timeout:
         _error("Timed out waiting for resources; exiting")
 
 

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -116,7 +116,7 @@ def wait_on_resources(namespace, timeout):
     """Wait for rolled out resources to be ready in namespace"""
     ready = wait_for_all_resources(namespace, timeout)
     if not ready:
-        _error("Timed out waiting for resources")
+        _error("Timed out waiting for resources; exiting")
 
 
 @namespace.command("prepare")

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -454,13 +454,13 @@ def _operator_resources(namespace, timeout):
 def wait_for_all_resources(namespace, timeout=300):
     # wrap the other wait_fors in 1 wait_for so overall timeout is honored
     # wait_for returns a tuple of the return code and the time taken 
-    rc, to = wait_for(
+    return_val, time_taken = wait_for(
         _operator_resources,
         func_args=(namespace, timeout),
         message="wait for all deployed resources to be ready",
         timeout=timeout,
     )
-    return rc
+    return time_taken
 
 
 def copy_namespace_secrets(src_namespace, dst_namespace, secret_names):

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -453,13 +453,13 @@ def _operator_resources(namespace, timeout):
 
 def wait_for_all_resources(namespace, timeout=300):
     # wrap the other wait_fors in 1 wait_for so overall timeout is honored
-    resources_ready = wait_for(
+    rc, to = wait_for(
         _operator_resources,
         func_args=(namespace, timeout),
         message="wait for all deployed resources to be ready",
         timeout=timeout,
     )
-    return resources_ready
+    return rc
 
 
 def copy_namespace_secrets(src_namespace, dst_namespace, secret_names):

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -453,12 +453,13 @@ def _operator_resources(namespace, timeout):
 
 def wait_for_all_resources(namespace, timeout=300):
     # wrap the other wait_fors in 1 wait_for so overall timeout is honored
-    wait_for(
+    resources_ready = wait_for(
         _operator_resources,
         func_args=(namespace, timeout),
         message="wait for all deployed resources to be ready",
         timeout=timeout,
     )
+    return resources_ready
 
 
 def copy_namespace_secrets(src_namespace, dst_namespace, secret_names):

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -453,6 +453,7 @@ def _operator_resources(namespace, timeout):
 
 def wait_for_all_resources(namespace, timeout=300):
     # wrap the other wait_fors in 1 wait_for so overall timeout is honored
+    # wait_for returns a tuple of the return code and the time taken 
     rc, to = wait_for(
         _operator_resources,
         func_args=(namespace, timeout),


### PR DESCRIPTION
* Adds an exit(1) if Bonfire times out waiting for resources
### Task failed successfully
``` bash
15:06:11 INFO:bonfire.openshift:[deploy/ingress] Waiting for deployment "ingress" rollout to finish: 0 of 1 updated replicas are available...
15:06:11 INFO:bonfire.openshift:[deploy/env-ephemeral-04-minio] is ready!
15:11:11 ERROR:bonfire.openshift:[deploy/ingress] timed out waiting for resource to be ready
15:11:11 INFO:bonfire.openshift:Some resources failed to become ready: deploy/ingress
15:11:11 INFO:bonfire.openshift:Waiting for resources owned by 'ClowdApp' to appear
15:11:12 ERROR: Timed out waiting for resources; exiting
15:11:12 bonfire namespace release ephemeral-04
15:11:12 ++ bonfire namespace release ephemeral-04
```