### PR TITLE
Make reconcile wait on base resources

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -175,9 +175,7 @@ def _reset(namespace):
     default=False,
 )
 @click.option(
-    "--namespace",
-    "-n",
-    help="Namespace you intend to deploy these components into",
+    "--namespace", "-n", help="Namespace you intend to deploy these components into",
 )
 def get_config(app, src_env, ref_env, set_template_ref, set_image_tag, get_dependencies, namespace):
     """Get kubernetes config for an app"""

--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -15,4 +15,4 @@ PROD_ENV_NAME = os.getenv("PROD_ENV_NAME", "insights-production")
 
 ENV_NAME_FORMAT = "env-{namespace}"
 
-RECONCILE_TIMEOUT = 120
+RECONCILE_TIMEOUT = os.getenv("RECONCILE_TIMEOUT", 120)

--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -14,3 +14,5 @@ EPHEMERAL_ENV_NAME = os.getenv("EPHEMERAL_ENV_NAME", "insights-ephemeral")
 PROD_ENV_NAME = os.getenv("PROD_ENV_NAME", "insights-production")
 
 ENV_NAME_FORMAT = "env-{namespace}"
+
+RECONCILE_TIMEOUT = 120

--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -249,6 +249,9 @@ def _reconcile_ns(ns):
     if update_needed:
         ns.update()
 
+    log.info("namespace '%s' - done", ns.name)
+
+
 
 def reconcile():
     namespaces = get_namespaces()

--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -6,11 +6,19 @@ import random
 import time
 import uuid
 import yaml
+import threading
 from pkg_resources import resource_filename
+from wait_for import TimedOutError
 
 import bonfire.config as conf
 from bonfire.qontract import get_namespaces_for_env, get_secret_names_in_namespace
-from bonfire.openshift import oc, get_json, copy_namespace_secrets, process_template
+from bonfire.openshift import (
+    oc,
+    get_json,
+    copy_namespace_secrets,
+    process_template,
+    wait_for_all_resources,
+)
 
 
 NS_RESERVED = "ephemeral-ns-reserved"
@@ -192,44 +200,62 @@ def add_base_resources(namespace):
 
     oc("apply", f="-", _in=json.dumps(processed_template))
 
+    # wait for any deployed base resources to become 'ready'
+    wait_for_all_resources(namespace, timeout=60, wait_on_app=False)
 
-def reconcile():
-    namespaces = get_namespaces()
-    for ns in namespaces:
-        log.info("namespace '%s' - checking", ns.name)
-        update_needed = False
 
-        if ns.reserved and ns.expires:
-            # check if the reservation has expired
-            utcnow = _utcnow()
-            log.info("namespace '%s' - expires: %s, utcnow: %s", ns.name, ns.expires, utcnow)
-            if utcnow > ns.expires:
-                log.info("namespace '%s' - reservation expired, releasing", ns.name)
-                ns.reserved = False
-                ns.ready = False
-                ns.duration = None
-                ns.expires = None
-                ns.requester = None
-                _delete_resources(ns.name)
-                update_needed = True
-            log.info("namespace '%s' - not expired", ns.name)
+def _reconcile_ns(ns):
+    log.info("namespace '%s' - checking", ns.name)
+    update_needed = False
 
-        if not ns.reserved and not ns.ready:
-            # check if any released namespaces need to be prepped
-            log.info("namespace '%s' - released but needs prep, prepping", ns.name)
+    if ns.reserved and ns.expires:
+        # check if the reservation has expired
+        utcnow = _utcnow()
+        log.info("namespace '%s' - expires: %s, utcnow: %s", ns.name, ns.expires, utcnow)
+        if utcnow > ns.expires:
+            log.info("namespace '%s' - reservation expired, releasing", ns.name)
+            ns.reserved = False
+            ns.ready = False
+            ns.duration = None
+            ns.expires = None
+            ns.requester = None
             _delete_resources(ns.name)
+            update_needed = True
+        log.info("namespace '%s' - not expired", ns.name)
+
+    if not ns.reserved and not ns.ready:
+        # check if any released namespaces need to be prepped
+        log.info("namespace '%s' - released but needs prep, prepping", ns.name)
+        _delete_resources(ns.name)
+        try:
             add_base_resources(ns.name)
+        except TimedOutError:
+            # base resources failed to come up, don't mark it ready and try again next time...
+            log.error("namespace '%s' - timed out waiting for resources after prep", ns.name)
+            pass
+        else:
             ns.ready = True
             ns.duration = None
             ns.expires = None
             ns.requester = None
             update_needed = True
 
-        if ns.reserved and ns.duration and not ns.expires:
-            # this is a newly reserved namespace, set the expires time
-            log.info("namespace '%s' - setting expiration time", ns.name)
-            ns.expires = _utcnow() + datetime.timedelta(minutes=ns.duration)
-            update_needed = True
+    if ns.reserved and ns.duration and not ns.expires:
+        # this is a newly reserved namespace, set the expires time
+        log.info("namespace '%s' - setting expiration time", ns.name)
+        ns.expires = _utcnow() + datetime.timedelta(minutes=ns.duration)
+        update_needed = True
 
-        if update_needed:
-            ns.update()
+    if update_needed:
+        ns.update()
+
+
+def reconcile():
+    namespaces = get_namespaces()
+    threads = []
+    for ns in namespaces:
+        t = threading.Thread(target=_reconcile_ns, args=(ns,))
+        threads.append(t)
+        t.start()
+    for t in threads:
+        t.join()

--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -201,7 +201,7 @@ def add_base_resources(namespace):
     oc("apply", f="-", _in=json.dumps(processed_template))
 
     # wait for any deployed base resources to become 'ready'
-    wait_for_all_resources(namespace, timeout=60, wait_on_app=False)
+    wait_for_all_resources(namespace, timeout=conf.RECONCILE_TIMEOUT, wait_on_app=False)
 
 
 def _reconcile_ns(ns):
@@ -250,7 +250,6 @@ def _reconcile_ns(ns):
         ns.update()
 
     log.info("namespace '%s' - done", ns.name)
-
 
 
 def reconcile():

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,6 @@ setup(
     setup_requires=["setuptools_scm"],
     include_package_data=True,
     install_requires=requirements,
-    classifiers=[
-        "Programming Language :: Python :: 3.6",
-    ],
+    classifiers=["Programming Language :: Python :: 3.6",],
     python_requires=">=3.6",
 )


### PR DESCRIPTION
* reconciler now calls `wait_on_all_resources` after adding base resources, so we wait for ClowdEnv deployments to go 'ready' before marking a namespace as 'ready'
* namespace reconciles run concurrently in threads now to speed up the reconciler