### PR TITLE
Add NAMESPACE env var to iqe pod

### DIFF
--- a/cicd/smoke_test.sh
+++ b/cicd/smoke_test.sh
@@ -12,7 +12,8 @@ python iqe_pod/create_iqe_pod.py $NAMESPACE \
     -e IQE_PLUGINS=$IQE_PLUGINS \
     -e IQE_MARKER_EXPRESSION=$IQE_MARKER_EXPRESSION \
     -e IQE_FILTER_EXPRESSION=$IQE_FILTER_EXPRESSION \
-    -e ENV_FOR_DYNACONF=smoke
+    -e ENV_FOR_DYNACONF=smoke \
+    -e NAMESPACE=$NAMESPACE
 
 oc cp -n $NAMESPACE iqe_pod/iqe_runner.sh $IQE_POD_NAME:/iqe_venv/iqe_runner.sh
 oc exec $IQE_POD_NAME -n $NAMESPACE -- bash /iqe_venv/iqe_runner.sh


### PR DESCRIPTION
needed for iqe env_parser
```
ValueError: ClowderEnvParser invoked but no 'namespace' given. Set NAMESPACE in env or set conf.VALUE_GETTERS.env_parser.namespace
```