### PR TITLE
Set NAMESPACE when deploy fails

### DIFF
--- a/cicd/deploy_ephemeral_env.sh
+++ b/cicd/deploy_ephemeral_env.sh
@@ -3,13 +3,11 @@ source ${CICD_ROOT}/_common_deploy_logic.sh
 # Deploy k8s resources for app and its dependencies (use insights-stage instead of insights-production for now)
 # -> use this PR as the template ref when downloading configurations for this component
 # -> use this PR's newly built image in the deployed configurations
-result=$(bonfire deploy \
+export NAMESPACE=$(bonfire namespace reserve)
+bonfire deploy \
     ${APP_NAME} \
     --source=appsre \
     --ref-env insights-stage \
     --set-template-ref ${APP_NAME}/${COMPONENT_NAME}=${GIT_COMMIT} \
-    --set-image-tag ${IMAGE}=${IMAGE_TAG})
-
-if [ $? -eq 0 ]; then
-    export NAMESPACE=$result
-fi
+    --set-image-tag ${IMAGE}=${IMAGE_TAG} \
+    --namespace ${NAMESPACE}


### PR DESCRIPTION
NAMESPACE env is needed in teardown to collect logs and release reserved namespace even when deploy fails

why was namespace exported only when deploy succeeded? I hope that bonfire is returning exit code other than 0 when deploy fails (and jenkins stops), so removing this code won't break anything
```bash
if [ $? -eq 0 ]; then
    export NAMESPACE=$result
fi
```