### PR TITLE
Fix missing set_image_tag argument

### DIFF
--- a/bonfire/local_config.py
+++ b/bonfire/local_config.py
@@ -122,7 +122,7 @@ def _add_dependencies_to_config(app_name, new_items, processed_apps, config):
         # recursively get config for any dependencies, they will be stored in the
         # already-created 'config' dict
         log.info("app '%s' dependencies %s not previously processed", app_name, dependencies)
-        items = process_local_config(config, dependencies, True, processed_apps)["items"]
+        items = process_local_config(config, dependencies, True, [], processed_apps)["items"]
         dep_items.extend(items)
 
     return dep_items


### PR DESCRIPTION
`bonfire local get --get-dependencies` fails when ClowdApp has dependencies because `processed_apps` is passed instead of `set_image_tag`

If I understood the code correctly `set_image_tag` is only used for `app` not for its `dependencies`. That's why I set it to `[]`