### PR TITLE
Remove imports from gh actions test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,7 @@ jobs:
           python -c "import pkg_resources; print(pkg_resources.get_distribution('crc-bonfire').version)"
           which bonfire
           bonfire --help
+          bonfire config write-default
 
   package:
     name: ⚙️ Build and Verify Package

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,8 +52,6 @@ jobs:
           python -m pip install pip --upgrade
           pip install -e .
           python -c "import pkg_resources; print(pkg_resources.get_distribution('crc-bonfire').version)"
-          python -c "import bonfire.config as conf"
-          python -c "from bonfire.local_config import process_local_config"
           which bonfire
           bonfire --help
 


### PR DESCRIPTION
No need to worry about importing specific internals in these simple tests. Running a couple CLI commands should catch import errors.