### PR TITLE
Fix namespace reservation issues when running against local k8s

### DIFF
--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -13,6 +13,7 @@ import bonfire.config as conf
 from bonfire.qontract import get_namespaces_for_env, get_secret_names_in_namespace
 from bonfire.openshift import (
     oc,
+    on_k8s,
     get_all_namespaces,
     get_json,
     copy_namespace_secrets,
@@ -133,6 +134,8 @@ class Namespace:
 
     @property
     def owned_by_me(self):
+        if on_k8s():
+            return True
         return self.requester_name == whoami()
 
     @property

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -619,7 +619,7 @@ def on_k8s():
 
 
 def get_all_namespaces():
-    if on_k8s():
+    if not on_k8s():
         all_namespaces = get_json("project")["items"]
     else:
         all_namespaces = get_json("namespace")["items"]

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -607,14 +607,21 @@ def wait_for_clowd_env_target_ns(clowd_env_name):
     ).out
 
 
-def get_all_namespaces():
+# assume that the result of this will not change during execution of a single 'bonfire' command
+@functools.lru_cache(maxsize=None, typed=False)
+def on_k8s():
+    """Detect whether this is a k8s or openshift cluster based on existence of projects."""
     project_resources = oc("api-resources", "--api-group=project.openshift.io", o="name")
 
     if str(project_resources).strip():
-        # we are on OpenShift, get projects
+        return False
+    return True
+
+
+def get_all_namespaces():
+    if on_k8s():
         all_namespaces = get_json("project")["items"]
     else:
-        # we are on k8s, get namespaces instead
         all_namespaces = get_json("namespace")["items"]
 
     return all_namespaces

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -611,7 +611,9 @@ def wait_for_clowd_env_target_ns(clowd_env_name):
 @functools.lru_cache(maxsize=None, typed=False)
 def on_k8s():
     """Detect whether this is a k8s or openshift cluster based on existence of projects."""
-    project_resources = oc("api-resources", "--api-group=project.openshift.io", o="name")
+    project_resources = oc(
+        "api-resources", "--api-group=project.openshift.io", o="name", _silent=True
+    )
 
     if str(project_resources).strip():
         return False


### PR DESCRIPTION
`oc whoami` won't work on a k8s cluster. The assumption is the only k8s cluster we'll be running bonfire against is a local k8s cluster that is not shared by anyone else. In that case, we'll just always return True for a `Namespace.is_owned_by_me` property.

This PR also adds more logic to detect whether we are on a cluster supporting namespace reservation when running commands like `namespace list`, `namespace reserve`, `namespace release`, and `deploy`