### PR TITLE
Remove duplicate short flag

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -261,8 +261,7 @@ _process_options = [
     ),
     click.option(
         "--set-template-ref",
-        "-t",
-        help="Override template ref for a component using format '<app>/<component>=<ref>'",
+        help="Override template ref for a component using format '<component>=<ref>'",
         multiple=True,
         callback=_validate_set_template_ref,
     ),


### PR DESCRIPTION
This removes the misleading `-t` short flag for `--set-template-ref`. Because`timeout` already defines this flag, `-t` gets interpreted as `timeout` instead.

The `<app>/<component>=<ref>` syntax is also deprecated according to a further log message, so this updates the help text for this option as well.