### PR TITLE
Check for marketplace host and port presence

### DIFF
--- a/cicd/iqe_pod/create_iqe_pod.py
+++ b/cicd/iqe_pod/create_iqe_pod.py
@@ -61,6 +61,10 @@ def _build_test_conf(env_parser):
 
     if env_parser.app_present("marketplace"):
         mp_storage_cfg = env_parser.get_storage_config("marketplace")
+        if mp_storage_cfg.get('hostname', '') == '':
+            raise
+        if mp_storage_cfg.get('port', '') == '':
+            raise
         bucket = env_parser.get_bucket_config("marketplace", "marketplace-s3")
         env_conf["MARKETPLACE"] = {
             "aws_access_key_id": bucket.accessKey,


### PR DESCRIPTION
If the configuration is missing hostname or port values, this will cause subsequent code to fail with a syntax error in the f-string on line 68. To prevent this error, perform some basic checking to confirm the existence of hostname and port. If they are not configured, raise an error.