### PR TITLE
Add `bonfire config edit` command for easy editing of local config

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -756,6 +756,13 @@ def _cmd_write_default_config(path):
     conf.write_default_config(path)
 
 
+@config.command("edit")
+@click.argument("path", required=False, type=str)
+def _cmd_edit_default_config(path):
+    """Edit configuration with $EDITOR (default path: $XDG_CONFIG_HOME/bonfire/config.yaml)"""
+    conf.edit_default_config(path)
+
+
 @options(_app_source_options)
 @click.option(
     "--components/--no-components",

--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -5,6 +5,7 @@ from pkg_resources import resource_filename
 import re
 import shutil
 import yaml
+import subprocess
 
 from dotenv import load_dotenv
 
@@ -66,6 +67,15 @@ def write_default_config(outpath=None):
     shutil.copy(inpath, outpath)
     outpath.chmod(0o600)
     log.info("saved config to: %s", outpath.absolute())
+
+
+def edit_default_config(confpath=None):
+    confpath = Path(confpath) if confpath else DEFAULT_CONFIG_PATH
+    if os.getenv("EDITOR") is None:
+        log.info("No $EDITOR set, exiting.")
+        return
+
+    subprocess.call([os.getenv("EDITOR"), confpath])
 
 
 def load_config(config_path=None):


### PR DESCRIPTION
:warning: First off: I am not a python programmer so this might be completely wrong. Roast me at your discretion!

I found myself wanting to immediately run `bonfire config edit` after running `bonfire config write-default` the first time - so I went ahead and added it here. I can't get it to quite run locally (somethign somethign `Starting path not found`), but from the looks of the `write-default` subcommand this might do the trick.

