### PR TITLE
RHCLOUD-14977 --no-remove-resources for specific components

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -236,6 +236,20 @@ def _validate_set_image_tag(ctx, param, value):
         raise click.BadParameter("format must be '<image uri>=<tag>'")
 
 
+def _validate_resource_arguments(ctx, param, value):
+    opposite_option = {
+        "remove_resources": "no_remove_resources",
+        "no_remove_resources": "remove_resources",
+    }
+    if "all" in value and "all" in ctx.params.get(opposite_option[param.name], {}):
+        raise click.BadParameter(
+            "--remove-resources and --no-remove-resources can't be both set to 'all'"
+        )
+    if param.name == "remove_resources" and not value:
+        value = ("all",)
+    return value
+
+
 _app_source_options = [
     click.option(
         "--source",
@@ -333,9 +347,24 @@ _process_options = [
         default=True,
     ),
     click.option(
-        "--remove-resources/--no-remove-resources",
-        help="Remove resource limits and requests on ClowdApp configs (default: true)",
-        default=True,
+        "--remove-resources",
+        help=(
+            "Remove resource limits and requests on ClowdApp configs "
+            "for specific components (default: all)"
+        ),
+        type=str,
+        multiple=True,
+        callback=_validate_resource_arguments,
+    ),
+    click.option(
+        "--no-remove-resources",
+        help=(
+            "Don't remove resource limits and requests on ClowdApp configs "
+            "for specific components (default: none)"
+        ),
+        type=str,
+        multiple=True,
+        callback=_validate_resource_arguments,
     ),
     click.option(
         "--single-replicas/--no-single-replicas",
@@ -536,6 +565,7 @@ def _process(
     clowd_env,
     local_config_path,
     remove_resources,
+    no_remove_resources,
     single_replicas,
     component_filter,
 ):
@@ -550,6 +580,7 @@ def _process(
         set_parameter,
         clowd_env,
         remove_resources,
+        no_remove_resources,
         single_replicas,
         component_filter,
     )
@@ -571,6 +602,7 @@ def _cmd_process(
     namespace,
     local_config_path,
     remove_resources,
+    no_remove_resources,
     single_replicas,
     component_filter,
 ):
@@ -589,6 +621,7 @@ def _cmd_process(
         clowd_env,
         local_config_path,
         remove_resources,
+        no_remove_resources,
         single_replicas,
         component_filter,
     )
@@ -623,6 +656,7 @@ def _cmd_config_deploy(
     clowd_env,
     local_config_path,
     remove_resources,
+    no_remove_resources,
     single_replicas,
     namespace,
     duration,
@@ -671,6 +705,7 @@ def _cmd_config_deploy(
             clowd_env,
             local_config_path,
             remove_resources,
+            no_remove_resources,
             single_replicas,
             component_filter,
         )

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -138,6 +138,7 @@ class TemplateProcessor:
         param_overrides,
         clowd_env,
         remove_resources,
+        no_remove_resources,
         single_replicas,
         component_filter,
     ):
@@ -151,6 +152,7 @@ class TemplateProcessor:
         self.param_overrides = param_overrides
         self.clowd_env = clowd_env
         self.remove_resources = remove_resources
+        self.no_remove_resources = no_remove_resources
         self.single_replicas = single_replicas
         self.component_filter = component_filter
 
@@ -254,7 +256,11 @@ class TemplateProcessor:
         # override the tags for all occurences of an image if requested
         new_items = self._sub_image_tags(new_items)
 
-        if self.remove_resources:
+        if (
+            "all" not in self.no_remove_resources
+            and ("all" in self.remove_resources or component_name in self.remove_resources)
+            and component_name not in self.no_remove_resources
+        ):
             _remove_resource_config(new_items)
         if self.single_replicas:
             _set_replicas(new_items)

--- a/cicd/deploy_ephemeral_db.sh
+++ b/cicd/deploy_ephemeral_db.sh
@@ -24,7 +24,8 @@ bonfire process \
     --set-image-tag $IMAGE=$IMAGE_TAG \
     --no-get-dependencies \
     --namespace $NAMESPACE \
-    $COMPONENTS_ARG | oc apply -f - -n $NAMESPACE
+    $COMPONENTS_ARG \
+    $COMPONENTS_RESOURCES_ARG | oc apply -f - -n $NAMESPACE
 
 bonfire namespace wait-on-resources $NAMESPACE --db-only
 

--- a/cicd/deploy_ephemeral_env.sh
+++ b/cicd/deploy_ephemeral_env.sh
@@ -11,4 +11,5 @@ bonfire deploy \
     --set-template-ref ${APP_NAME}/${COMPONENT_NAME}=${GIT_COMMIT} \
     --set-image-tag ${IMAGE}=${IMAGE_TAG} \
     --namespace ${NAMESPACE} \
-    ${COMPONENTS_ARG}
+    ${COMPONENTS_ARG} \
+    ${COMPONENTS_RESOURCES_ARG}


### PR DESCRIPTION
- use --remove-resources/--no-remove-resources with argument e.g. `--remove-resources all --no-remove-resources vmaas --no-remove-resources something-else`
- don't allow to use `--remove-resources all --no-remove-resources all`
- `COMPONENTS_W_RESOURCES`env var for PR check to set which components should respect resources settings from clowdapp
- **it's a breaking change** - `--remove-resources/--no-remove-resources` expects 1 argument