### PR TITLE
Remove duplicate options from process and deploy

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -297,12 +297,6 @@ _process_options = [
         callback=_validate_set_parameter,
     ),
     click.option(
-        "--namespace",
-        "-n",
-        help="Namespace you intend to deploy to (default: none)",
-        type=str,
-    ),
-    click.option(
         "--clowd-env",
         "-e",
         help=(
@@ -312,15 +306,6 @@ _process_options = [
         default=None,
     ),
     _app_source_options[2],
-    click.option(
-        "--target-env",
-        help=(
-            f"When using source={APP_SRE_SRC}, name of environment to fetch templates for"
-            f" (default: {conf.EPHEMERAL_ENV_NAME})"
-        ),
-        type=str,
-        default=conf.EPHEMERAL_ENV_NAME,
-    ),
     click.option(
         "--ref-env",
         help=f"Query {APP_SRE_SRC} for apps in this environment and substitute 'ref'/'IMAGE_TAG'",
@@ -558,6 +543,12 @@ def _process(
 
 @main.command("process")
 @options(_process_options)
+@click.option(
+    "--namespace",
+    "-n",
+    help="Namespace you intend to deploy to (default: none)",
+    type=str,
+)
 def _cmd_process(
     app_names,
     source,


### PR DESCRIPTION
Its a just cosmetic thing, but it was obvious and needed fixing (IMO).

Before patch:
```
(bonfire_venv) [mhuth@mhuth-laptop bonfire]$ bonfire deploy --help | egrep -- '--namespace|--target-env'
  -n, --namespace TEXT            Namespace you intend to deploy to (default:
  --target-env TEXT               When using source=appsre, name of
  --target-env TEXT               When using source=appsre, name of
  -n, --namespace TEXT            Namespace to deploy to (if none given,

(bonfire_venv) [mhuth@mhuth-laptop bonfire]$ bonfire process --help | egrep -- '--namespace|--target-env'
  -n, --namespace TEXT            Namespace you intend to deploy to (default:
  --target-env TEXT               When using source=appsre, name of
  --target-env TEXT               When using source=appsre, name of
```

After:
```
(bonfire_venv) [mhuth@mhuth-laptop bonfire]$ bonfire deploy --help | egrep -- '--namespace|--target-env'
  --target-env TEXT               When using source=appsre, name of
  -n, --namespace TEXT            Namespace to deploy to (if none given,

(bonfire_venv) [mhuth@mhuth-laptop bonfire]$ bonfire process --help | egrep -- '--namespace|--target-env'
  --target-env TEXT               When using source=appsre, name of
  -n, --namespace TEXT            Namespace you intend to deploy to (default:
```
