### PR TITLE
Explicitly set the private web port to 10000

### DIFF
--- a/bonfire/resources/ephemeral-clowdenvironment.yaml
+++ b/bonfire/resources/ephemeral-clowdenvironment.yaml
@@ -36,6 +36,7 @@ objects:
               memory: 256Mi
       web:
         port: 8000
+        privatePort: 10000
         mode: operator
       featureFlags:
         mode: local


### PR DESCRIPTION
Currently, people have to [dig through the clowder code](https://github.com/RedHatInsights/clowder/blob/e472159f10077105a4c9c83e26c87c0bce712b26/controllers/cloud.redhat.com/providers/web/default.go#L24) to figure out what this private web port is. We should instead make it explicit by setting it here in the default ClowdEnv.