### PR TITLE
Add flag to specify quay user in pullSecret

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -376,6 +376,12 @@ _clowdenv_process_options = [
         type=str,
     ),
     click.option(
+        "--quay-user",
+        "-u",
+        help="Quay username for pullSecret provider",
+        type=str,
+    ),
+    click.option(
         "--clowd-env",
         "-e",
         help=(f"Name of ClowdEnvironment (default: if target ns provided, {conf.ENV_NAME_FORMAT})"),
@@ -785,11 +791,11 @@ def _cmd_config_deploy(
         click.echo(ns)
 
 
-def _process_clowdenv(target_namespace, env_name, template_file):
+def _process_clowdenv(target_namespace, quay_user, env_name, template_file):
     env_name = _get_env_name(target_namespace, env_name)
 
     try:
-        clowd_env_config = process_clowd_env(target_namespace, env_name, template_file)
+        clowd_env_config = process_clowd_env(target_namespace, quay_user, env_name, template_file)
     except ValueError as err:
         _error(str(err))
 
@@ -798,21 +804,21 @@ def _process_clowdenv(target_namespace, env_name, template_file):
 
 @main.command("process-env")
 @options(_clowdenv_process_options)
-def _cmd_process_clowdenv(namespace, clowd_env, template_file):
+def _cmd_process_clowdenv(namespace, quay_user, clowd_env, template_file):
     """Process ClowdEnv template and print output"""
-    clowd_env_config = _process_clowdenv(namespace, clowd_env, template_file)
+    clowd_env_config = _process_clowdenv(namespace, quay_user, clowd_env, template_file)
     print(json.dumps(clowd_env_config, indent=2))
 
 
 @main.command("deploy-env")
 @options(_clowdenv_process_options)
 @options(_timeout_option)
-def _cmd_deploy_clowdenv(namespace, clowd_env, template_file, timeout):
+def _cmd_deploy_clowdenv(namespace, quay_user, clowd_env, template_file, timeout):
     """Process ClowdEnv template and deploy to a cluster"""
     _warn_if_unsafe(namespace)
 
     try:
-        clowd_env_config = _process_clowdenv(namespace, clowd_env, template_file)
+        clowd_env_config = _process_clowdenv(namespace, quay_user, clowd_env, template_file)
 
         log.debug("ClowdEnvironment config:\n%s", clowd_env_config)
 

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -52,7 +52,7 @@ def _set_replicas(items):
             log.debug("set replicas to '1' on ClowdApp '%s'", i["metadata"]["name"])
 
 
-def process_clowd_env(target_ns, env_name, template_path):
+def process_clowd_env(target_ns, quay_user, env_name, template_path):
     log.info("processing ClowdEnvironment")
 
     env_template_path = Path(template_path if template_path else conf.DEFAULT_CLOWDENV_TEMPLATE)
@@ -65,8 +65,11 @@ def process_clowd_env(target_ns, env_name, template_path):
 
     params = dict()
     params["ENV_NAME"] = env_name
+    if quay_user:
+        params["PULL_SECRET_NAME"] = f"{quay_user}-pull-secret"
     if target_ns:
         params["NAMESPACE"] = target_ns
+        params["PULL_SECRET_NAMESPACE"] = target_ns
 
     processed_template = process_template(template_data, params=params)
 

--- a/bonfire/resources/ephemeral-clowdenvironment.yaml
+++ b/bonfire/resources/ephemeral-clowdenvironment.yaml
@@ -18,6 +18,9 @@ objects:
         cpu: 30m
         memory: 128Mi
     providers:
+      pullSecrets:
+        - name: ${PULL_SECRET_NAME}
+          namespace: ${PULL_SECRET_NAMESPACE}
       testing:
         # Level of access the testing pod has in the namespace
         k8sAccessLevel: edit
@@ -70,3 +73,7 @@ parameters:
 - name: ENV_NAME
   description: Name of the ClowdEnvironment
   required: true
+- name: PULL_SECRET_NAME
+  value: quay-cloudservices-pull
+- name: PULL_SECRET_NAMESPACE
+  value: ephemeral-base


### PR DESCRIPTION
Currently, devs all have a uniquely named quay pull secret based on their username from quay.io. This command allows the specified username to be prepended to the pull secret name in the `deploy-env` command. By enabling the pull secret provider in the ClowdEnvironment, devs can now run a single command and import their pull secret for use, rather than manually editing the ClowdEnviornment. 

* Adds a `-u` or `--quay-user` flag to `bonfire deploy-env` that specifies the username for the pull secret
* Will default to `quay-cloudservies-pull` if no user is provided
* Updates the ephemeral env to include both `PULL_SECRET_NAMESPACE` and `PULL_SECRET_NAME`, mirroring both stage and prod's behavior.