### PR TITLE
Don't look up commit hash for master/main/stable

### DIFF
--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -237,7 +237,7 @@ class RepoFile:
 
     def _fetch_github(self):
         commit = self.ref
-        if not GIT_SHA_RE.match(commit):
+        if not GIT_SHA_RE.match(commit) and commit not in ("master", "main", "stable"):
             # look up the commit hash for this branch
             commit = self._get_gh_commit_hash()
 


### PR DESCRIPTION
Avoid gh api rate limiting by using branch name as ref for github raw file, there is no need to access gh api

However we need to look up commit hash if PR is not rebased and this can reach gh api limit again. So this is a workaround, not the actual fix for the issue.