### PR TITLE
Fix -u option to handle underscores

### DIFF
--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -66,6 +66,7 @@ def process_clowd_env(target_ns, quay_user, env_name, template_path):
     params = dict()
     params["ENV_NAME"] = env_name
     if quay_user:
+        quay_user = quay_user.replace("_", "-")
         params["PULL_SECRET_NAME"] = f"{quay_user}-pull-secret"
     if target_ns:
         params["NAMESPACE"] = target_ns


### PR DESCRIPTION
Quay does some manipulation on usernames internally. If the username includes `_`, they are modified to `-` during pull secret creation. Bonfire will mimic this behavior in order to provide a cleaner and more correct user experience. 
