### PR TITLE
Support for importing secrets from local dir

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -706,7 +706,7 @@ def _cmd_process(
 @click.option(
     "--secrets-dir",
     type=str,
-    help="Import secrets from this directory (default: " "$XDG_CONFIG_HOME/bonfire/secrets/)",
+    help="Directory to use for secrets import (default: " "$XDG_CONFIG_HOME/bonfire/secrets/)",
     default=conf.DEFAULT_SECRETS_DIR,
 )
 @click.option(

--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -4,11 +4,11 @@ from pathlib import Path
 from pkg_resources import resource_filename
 import re
 import shutil
-import yaml
 import subprocess
 
 from dotenv import load_dotenv
 
+from bonfire.utils import load_file
 
 log = logging.getLogger(__name__)
 
@@ -25,6 +25,7 @@ def _get_config_path():
 
 DEFAULT_CONFIG_PATH = _get_config_path().joinpath("config.yaml")
 DEFAULT_ENV_PATH = _get_config_path().joinpath("env")
+DEFAULT_SECRETS_DIR = _get_config_path().joinpath("secrets")
 DEFAULT_CLOWDENV_TEMPLATE = resource_filename(
     "bonfire", "resources/local-cluster-clowdenvironment.yaml"
 )
@@ -57,11 +58,6 @@ RESERVABLE_NAMESPACE_REGEX = re.compile(os.getenv("RESERVABLE_NAMESPACE_REGEX", 
 EPHEMERAL_ENV_NAME = os.getenv("EPHEMERAL_ENV_NAME", "insights-ephemeral")
 RECONCILE_TIMEOUT = os.getenv("RECONCILE_TIMEOUT", 600)
 ENV_NAME_FORMAT = os.getenv("ENV_NAME_FORMAT", "env-{namespace}")
-
-
-def _load_file(path):
-    with path.open() as fp:
-        return yaml.safe_load(fp)
 
 
 def write_default_config(outpath=None):
@@ -99,6 +95,6 @@ def load_config(config_path=None):
                 log.info("default config not found, creating")
 
     log.info("using local config file: %s", str(config_path.absolute()))
-    local_config_data = _load_file(config_path)
+    local_config_data = load_file(config_path)
 
     return local_config_data

--- a/bonfire/secrets.py
+++ b/bonfire/secrets.py
@@ -1,0 +1,79 @@
+"""
+Handles importing of secrets from a local directory
+"""
+import glob
+import json
+import logging
+import os
+
+from bonfire.openshift import oc, get_json
+from bonfire.utils import load_file
+
+
+log = logging.getLogger(__name__)
+
+
+def _parse_secret_file(path):
+    """
+    Return a dict of all secrets in a file with key: secret name, val: parsed secret json/yaml
+    The file can contain 1 secret, or a list of secrets
+    """
+    content = load_file(path)
+    secrets = {}
+    if content.get("kind").lower() == "list":
+        items = content.get("items", [])
+    else:
+        items = [content]
+
+    for item in items:
+        if item.get("kind").lower() == "secret":
+            try:
+                secrets[item["metadata"]["name"]] = item
+            except KeyError:
+                raise ValueError("Secret at path '{}' has no metadata/name".format(path))
+
+    return secrets
+
+
+def _get_files_in_dir(path):
+    """
+    Get a list of all .yml/.yaml/.json files in a dir
+    """
+    files = list(glob.glob(os.path.join(path, "*.yaml")))
+    files.extend(list(glob.glob(os.path.join(path, "*.yml"))))
+    files.extend(list(glob.glob(os.path.join(path, "*.json"))))
+    return files
+
+
+def _import_secret(secret_name, secret_data):
+    # get existing secret in the ns (if it exists)
+    current_secret = get_json("secret", secret_name) or {}
+
+    # avoid race conditions when running multiple processes by comparing the data
+    if current_secret.get("data") != secret_data.get("data"):
+        log.info("replacing secret '%s' using local copy", secret_name)
+        # delete from dst ns so that applying 'null' values will work
+        oc("delete", "--ignore-not-found", "secret", secret_name, _silent=True)
+        oc("apply", "-f", "-", _silent=True, _in=json.dumps(secret_data))
+
+
+def import_secrets_from_dir(path):
+    if not os.path.exists(path):
+        raise ValueError(f"secrets directory not found: {path}")
+
+    if not os.path.isdir(path):
+        raise ValueError(f"invalid secrets directory: {path}")
+
+    files = _get_files_in_dir(path)
+    secrets = {}
+    log.info("importing secrets from local path: %s", path)
+    for secret_file in files:
+        secrets_in_file = _parse_secret_file(secret_file)
+        log.info("loaded %d secret(s) from file '%s'", len(secrets_in_file), secret_file)
+        for secret_name in secrets_in_file:
+            if secret_name in secrets:
+                raise ValueError(f"secret with name '{secret_name}' defined twice in secrets dir")
+        secrets.update(secrets_in_file)
+
+    for secret_name, secret_data in secrets.items():
+        _import_secret(secret_name, secret_data)

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -1,4 +1,5 @@
 import atexit
+import json
 import logging
 import os
 import re
@@ -6,6 +7,7 @@ import requests
 import shlex
 import subprocess
 import tempfile
+import yaml
 
 from cached_property import cached_property
 
@@ -286,3 +288,24 @@ class RepoFile:
         p = os.path.join(repo_dir, self.path.lstrip("/"))
         with open(p) as fp:
             return commit, fp.read()
+
+
+def load_file(path):
+    """Load a .json/.yml/.yaml file."""
+    if not os.path.isfile(path):
+        raise ValueError("Path '{}' is not a file or does not exist".format(path))
+
+    _, file_ext = os.path.splitext(path)
+
+    with open(path, "rb") as f:
+        if file_ext == ".yaml" or file_ext == ".yml":
+            content = yaml.safe_load(f)
+        elif file_ext == ".json":
+            content = json.load(f)
+        else:
+            raise ValueError("File '{}' must be a YAML or JSON file".format(path))
+
+    if not content:
+        raise ValueError("File '{}' is empty!".format(path))
+
+    return content


### PR DESCRIPTION
This adds two CLI options to `deploy` and `deploy-env`:

```
  --import-secrets                Import secrets from local directory at
                                  deploy time

  --secrets-dir TEXT              Directory to use for secrets import
                                  (default: $XDG_CONFIG_HOME/bonfire/secrets/)
```

If there are any .yaml/.yml/.json files which contain a `Secret` or list of `Secret` items stored in the secrets dir, bonfire will import them during deploy time after the target namespace is determined.