### PR TITLE
split on first equals

### DIFF
--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -86,7 +86,7 @@ def split_equals(list_of_str, allow_null=False):
             raise ValueError(
                 f"invalid format for value '{item}', must match: r'{equals_regex.pattern}'"
             )
-        key, val = item.split("=")
+        key, val = item.split("=", 1)
         output[key] = val
 
     return output


### PR DESCRIPTION
While calling `--set-parameter`, I hit an issue when my `<value>` contains an `=` sign. This PR updates `split_equals` to split at most 1 time.

```python
>>> import re
>>> equals_regex = re.compile(r"^\S+=[\S ]+$")
>>> s = "<component>/<param>=<valuewithan=>"
>>> not equals_regex.match(s)
False
>>> key, val = s.split("=")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: too many values to unpack (expected 2)
>>> key, val = s.split("=", 1)
>>> key
'<component>/<param>'
>>> val
'<valuewithan=>'
```