### PR TITLE
Add check against invalid cluster session

### DIFF
--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -16,6 +16,14 @@ from wait_for import wait_for, TimedOutError
 log = logging.getLogger(__name__)
 
 
+def run_oc_status():
+    try:
+        oc("status", _silent=True)
+        return True
+    except ErrorReturnCode:
+        return False
+
+
 # assume that the result of this will not change during execution of our app
 @functools.lru_cache(maxsize=None, typed=False)
 def get_api_resources():
@@ -668,10 +676,14 @@ def on_k8s():
 
 
 def get_all_namespaces():
-    if not on_k8s():
-        all_namespaces = get_json("project")["items"]
+
+    if run_oc_status():
+        if not on_k8s():
+            all_namespaces = get_json("project")["items"]
+        else:
+            all_namespaces = get_json("namespace")["items"]
     else:
-        all_namespaces = get_json("namespace")["items"]
+        raise ValueError("Error running oc status, check cluster login session")
 
     return all_namespaces
 


### PR DESCRIPTION
Fixes #95 

Adds a small helper function to check with `oc status` the existing K8s cluster session. This mainly happens on the `get_namespaces` action, which is the entrypoint for most of the actions related with the `deploy` action, so I think it makes sense to do it right there, but maybe is required elsewhere, some input is welcome :) 