### PR TITLE
Catch empty config files and other value errors

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -569,7 +569,11 @@ def _cmd_namespace_reset(namespace):
 
 
 def _get_apps_config(source, target_env, ref_env, local_config_path):
-    config = conf.load_config(local_config_path)
+    try:
+        config = conf.load_config(local_config_path)
+    except ValueError as err:
+        log.warning("config file looks suspicious: %s", err)
+        config = {}
 
     if source == APP_SRE_SRC:
         log.info("fetching apps config using source: %s, target env: %s", source, target_env)
@@ -795,6 +799,9 @@ def _cmd_config_deploy(
             apply_config(ns, apps_config)
             log.info("waiting on resources for max of %dsec...", timeout)
             _wait_on_namespace_resources(ns, timeout)
+    except ValueError as err:
+        log.error(err)
+        _err_handler()
     except KeyboardInterrupt:
         log.error("Aborted by keyboard interrupt!")
         _err_handler()


### PR DESCRIPTION
For usability, catch all value errors and log them, for example,
when the config.yaml file is empty or have only comments, then
just log it, instead of throw an exception. Returns an error to shell.

Example: It happened to have a "empty" (only comments) `config.yaml` left when I was trying to execute bonfire (a mistake) and I've got this output...

```
...
2021-08-24 16:36:50 [    INFO] [           pid-20687]  |stdout| namespace/ephemeral-20 patched
2021-08-24 16:36:58 [    INFO] [          MainThread] processing app templates...
2021-08-24 16:36:58 [    INFO] [          MainThread] using local config file: /Users/rmoura/config.yaml
2021-08-24 16:36:58 [   ERROR] [          MainThread] hit unexpected error!
Traceback (most recent call last):
  File "/Users/rmoura/.virtualenvs/tools/lib/python3.9/site-packages/bonfire/bonfire.py", line 774, in _cmd_config_deploy
    apps_config = _process(
  File "/Users/rmoura/.virtualenvs/tools/lib/python3.9/site-packages/bonfire/bonfire.py", line 627, in _process
    apps_config = _get_apps_config(source, target_env, ref_env, local_config_path)
  File "/Users/rmoura/.virtualenvs/tools/lib/python3.9/site-packages/bonfire/bonfire.py", line 572, in _get_apps_config
    config = conf.load_config(local_config_path)
  File "/Users/rmoura/.virtualenvs/tools/lib/python3.9/site-packages/bonfire/config.py", line 98, in load_config
    local_config_data = load_file(config_path)
  File "/Users/rmoura/.virtualenvs/tools/lib/python3.9/site-packages/bonfire/utils.py", line 375, in load_file
    raise ValueError("File '{}' is empty!".format(path))
ValueError: File 'config.yaml' is empty!
ERROR: deploy failed
```

After applying this commit, the output is clean:

```
2021-08-24 18:21:57 [    INFO] [          MainThread] reserving ephemeral namespace 'ephemeral-20'...
2021-08-24 18:21:58 [    INFO] [          MainThread] attempt [1] to reserve namespace ephemeral-20
2021-08-24 18:21:59 [ WARNING] [          MainThread] namespace owned by you but expires time unknown, not renewing
2021-08-24 18:22:01 [    INFO] [          MainThread] processing app templates...
2021-08-24 18:22:01 [    INFO] [          MainThread] using local config file: /Users/rmoura/config.yaml
2021-08-24 18:22:01 [ WARNING] [          MainThread] config file looks suspicious: File 'config.yaml' is empty!
2021-08-24 18:22:01 [    INFO] [          MainThread] fetching apps config using source: local
2021-08-24 18:22:01 [    INFO] [          MainThread] processing app 'rbac'
2021-08-24 18:22:01 [   ERROR] [          MainThread] app rbac not found in apps config
ERROR: deploy failed
```

The `config.yaml` looks like this:

```
# This file can update the JupyterHub Helm chart's default configuration values.
#
# For reference see the configuration reference and default values, but make
# sure to refer to the Helm chart version of interest to you!
#
# Introduction to YAML:     https://www.youtube.com/watch?v=cdLNKUoMc6c
# Chart config reference:   https://zero-to-jupyterhub.readthedocs.io/en/stable/resources/reference.html
# Chart default values:     https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/HEAD/jupyterhub/values.yaml
# Available chart versions: https://jupyterhub.github.io/helm-chart/
#
```