### PR TITLE
Raise custom FatalError for cleaner error msgs

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -20,7 +20,7 @@ from bonfire.openshift import (
     wait_for_clowd_env_target_ns,
     wait_on_cji,
 )
-from bonfire.utils import split_equals, find_what_depends_on
+from bonfire.utils import FatalError, split_equals, find_what_depends_on
 from bonfire.local import get_local_apps
 from bonfire.processor import TemplateProcessor, process_clowd_env, process_iqe_cji
 from bonfire.namespaces import (
@@ -811,13 +811,7 @@ def _cmd_config_deploy(
 
 def _process_clowdenv(target_namespace, quay_user, env_name, template_file):
     env_name = _get_env_name(target_namespace, env_name)
-
-    try:
-        clowd_env_config = process_clowd_env(target_namespace, quay_user, env_name, template_file)
-    except ValueError as err:
-        _error(str(err))
-
-    return clowd_env_config
+    return process_clowd_env(target_namespace, quay_user, env_name, template_file)
 
 
 @main.command("process-env")
@@ -1005,4 +999,7 @@ def _cmd_apps_what_depends_on(
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except FatalError as err:
+        _error(str(err))

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -759,7 +759,7 @@ def _cmd_config_deploy(
         clowd_env = match["metadata"]["name"]
         log.debug("inferred clowd_env: '%s'", clowd_env)
 
-    def _err_handler():
+    def _err_handler(err):
         try:
             if not no_release_on_fail and not requested_ns and used_ns_reservation_system:
                 # if we auto-reserved this ns, auto-release it on failure unless
@@ -767,7 +767,8 @@ def _cmd_config_deploy(
                 log.info("releasing namespace '%s'", ns)
                 release_namespace(ns)
         finally:
-            _error("deploy failed")
+            msg = f"deploy failed: {str(err)}"
+            _error(msg)
 
     try:
         log.info("processing app templates...")
@@ -795,15 +796,18 @@ def _cmd_config_deploy(
             apply_config(ns, apps_config)
             log.info("waiting on resources for max of %dsec...", timeout)
             _wait_on_namespace_resources(ns, timeout)
-    except KeyboardInterrupt:
-        log.error("Aborted by keyboard interrupt!")
-        _err_handler()
+    except KeyboardInterrupt as err:
+        log.error("aborted by keyboard interrupt!")
+        _err_handler(err)
     except TimedOutError as err:
-        log.error("Hit timeout error: %s", err)
-        _err_handler()
-    except Exception:
+        log.error("hit timeout error: %s", err)
+        _err_handler(err)
+    except FatalError as err:
+        log.error("hit fatal error: %s", err)
+        _err_handler(err)
+    except Exception as err:
         log.exception("hit unexpected error!")
-        _err_handler()
+        _err_handler(err)
     else:
         log.info("successfully deployed to namespace '%s'", ns)
         click.echo(ns)
@@ -843,6 +847,10 @@ def _cmd_deploy_clowdenv(
     """Process ClowdEnv template and deploy to a cluster"""
     _warn_if_unsafe(namespace)
 
+    def _err_handler(err):
+        msg = f"deploy failed: {str(err)}"
+        _error(msg)
+
     try:
         if import_secrets:
             import_secrets_from_dir(secrets_dir)
@@ -861,15 +869,18 @@ def _cmd_deploy_clowdenv(
         _wait_on_namespace_resources(namespace, timeout)
 
         clowd_env_name = find_clowd_env_for_ns(namespace)["metadata"]["name"]
-    except KeyboardInterrupt:
-        log.error("Aborted by keyboard interrupt!")
-        _error("deploy failed")
+    except KeyboardInterrupt as err:
+        log.error("aborted by keyboard interrupt!")
+        _err_handler(err)
     except TimedOutError as err:
-        log.error("Hit timeout error: %s", err)
-        _error("deploy failed")
-    except Exception:
+        log.error("hit timeout error: %s", err)
+        _err_handler(err)
+    except FatalError as err:
+        log.error("hit fatal error: %s", err)
+        _err_handler(err)
+    except Exception as err:
         log.exception("hit unexpected error!")
-        _error("deploy failed")
+        _err_handler(err)
     else:
         log.info("ClowdEnvironment '%s' using ns '%s' is ready", clowd_env_name, namespace)
         click.echo(namespace)
@@ -906,6 +917,10 @@ def _cmd_deploy_iqe_cji(
     """Process IQE CJI template, apply it, and wait for it to start running."""
     _warn_if_unsafe(namespace)
 
+    def _err_handler(err):
+        msg = f"deploy failed: {str(err)}"
+        _error(msg)
+
     try:
         cji_config = process_iqe_cji(
             clowd_app_name, debug, marker, filter, env, image_tag, cji_name, template_file
@@ -922,15 +937,18 @@ def _cmd_deploy_iqe_cji(
 
         log.info("waiting on CJI '%s' for max of %dsec...", cji_name, timeout)
         pod_name = wait_on_cji(namespace, cji_name, timeout)
-    except KeyboardInterrupt:
-        log.error("Aborted by keyboard interrupt!")
-        _error("deploy failed")
+    except KeyboardInterrupt as err:
+        log.error("aborted by keyboard interrupt!")
+        _err_handler(err)
     except TimedOutError as err:
-        log.error("Hit timeout error: %s", err)
-        _error("deploy failed")
-    except Exception:
+        log.error("hit timeout error: %s", err)
+        _err_handler(err)
+    except FatalError as err:
+        log.error("hit fatal error: %s", err)
+        _err_handler(err)
+    except Exception as err:
         log.exception("hit unexpected error!")
-        _error("deploy failed")
+        _err_handler(err)
     else:
         log.info(
             "pod '%s' related to CJI '%s' in ns '%s' is running", pod_name, cji_name, namespace

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -998,8 +998,12 @@ def _cmd_apps_what_depends_on(
     print("\n".join(found) or f"no apps depending on {component} found")
 
 
-if __name__ == "__main__":
+def main_with_handler():
     try:
         main()
     except FatalError as err:
         _error(str(err))
+
+
+if __name__ == "__main__":
+    main_with_handler()

--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -8,7 +8,7 @@ import subprocess
 
 from dotenv import load_dotenv
 
-from bonfire.utils import load_file
+from bonfire.utils import load_file, FatalError
 
 log = logging.getLogger(__name__)
 
@@ -83,7 +83,7 @@ def load_config(config_path=None):
         log.debug("user provided explicit config path: %s", config_path)
         config_path = Path(config_path)
         if not config_path.exists():
-            raise ValueError(f"provided config file path '{str(config_path)}' does not exist")
+            raise FatalError(f"provided config file path '{str(config_path)}' does not exist")
     else:
         # no user-provided path, check default locations
         config_path = Path("config.yaml")

--- a/bonfire/local.py
+++ b/bonfire/local.py
@@ -1,7 +1,7 @@
 import logging
 import yaml
 
-from bonfire.utils import RepoFile, get_dupes
+from bonfire.utils import RepoFile, get_dupes, FatalError
 
 log = logging.getLogger(__name__)
 
@@ -20,12 +20,12 @@ def _fetch_apps_file(config):
     fetched_apps = yaml.safe_load(content)
 
     if "apps" not in fetched_apps:
-        raise ValueError("fetched apps file has no 'apps' key")
+        raise FatalError("fetched apps file has no 'apps' key")
 
     app_names = [a["name"] for a in fetched_apps["apps"]]
     dupes = get_dupes(app_names)
     if dupes:
-        raise ValueError("duplicate app names found in fetched apps file: {dupes}")
+        raise FatalError("duplicate app names found in fetched apps file: {dupes}")
 
     return {a["name"]: a for a in fetched_apps["apps"]}
 
@@ -34,7 +34,7 @@ def _parse_apps_in_cfg(config):
     app_names = [a["name"] for a in config["apps"]]
     dupes = get_dupes(app_names)
     if dupes:
-        raise ValueError("duplicate app names found in config: {dupes}")
+        raise FatalError("duplicate app names found in config: {dupes}")
     return {a["name"]: a for a in config["apps"]}
 
 

--- a/bonfire/secrets.py
+++ b/bonfire/secrets.py
@@ -7,7 +7,7 @@ import logging
 import os
 
 from bonfire.openshift import oc, get_json
-from bonfire.utils import load_file
+from bonfire.utils import load_file, FatalError
 
 
 log = logging.getLogger(__name__)
@@ -30,7 +30,7 @@ def _parse_secret_file(path):
             try:
                 secrets[item["metadata"]["name"]] = item
             except KeyError:
-                raise ValueError("Secret at path '{}' has no metadata/name".format(path))
+                raise FatalError("Secret at path '{}' has no metadata/name".format(path))
 
     return secrets
 
@@ -61,10 +61,10 @@ def _import_secret(secret_name, secret_data):
 
 def import_secrets_from_dir(path):
     if not os.path.exists(path):
-        raise ValueError(f"secrets directory not found: {path}")
+        raise FatalError(f"secrets directory not found: {path}")
 
     if not os.path.isdir(path):
-        raise ValueError(f"invalid secrets directory: {path}")
+        raise FatalError(f"invalid secrets directory: {path}")
 
     files = _get_files_in_dir(path)
     secrets = {}
@@ -74,7 +74,7 @@ def import_secrets_from_dir(path):
         log.info("loaded %d secret(s) from file '%s'", len(secrets_in_file), secret_file)
         for secret_name in secrets_in_file:
             if secret_name in secrets:
-                raise ValueError(f"secret with name '{secret_name}' defined twice in secrets dir")
+                raise FatalError(f"secret with name '{secret_name}' defined twice in secrets dir")
         secrets.update(secrets_in_file)
 
     for secret_name, secret_data in secrets.items():

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -14,6 +14,7 @@ from cached_property import cached_property
 
 class FatalError(Exception):
     """An exception that will cause the CLI to exit"""
+
     pass
 
 

--- a/entry_points.txt
+++ b/entry_points.txt
@@ -1,2 +1,2 @@
 [console_scripts]
-bonfire = bonfire.bonfire:main
+bonfire = bonfire.bonfire:main_with_handler


### PR DESCRIPTION
For error messages that should cause the CLI to exit with a "clean" message, raise a FatalError. FatalError will be caught when running `main()` and the error message is printed with no traceback.