### PR TITLE
Update set-template-ref syntax on helper scripts

### DIFF
--- a/cicd/deploy_ephemeral_db.sh
+++ b/cicd/deploy_ephemeral_db.sh
@@ -15,7 +15,7 @@ bonfire process \
     $APP_NAME \
     --source=appsre \
     --ref-env insights-stage \
-    --set-template-ref ${APP_NAME}/${COMPONENT_NAME}=${GIT_COMMIT} \
+    --set-template-ref ${COMPONENT_NAME}=${GIT_COMMIT} \
     --set-image-tag $IMAGE=$IMAGE_TAG \
     --namespace $NAMESPACE \
     --no-get-dependencies \

--- a/cicd/deploy_ephemeral_env.sh
+++ b/cicd/deploy_ephemeral_env.sh
@@ -8,7 +8,7 @@ bonfire deploy \
     ${APP_NAME} \
     --source=appsre \
     --ref-env insights-stage \
-    --set-template-ref ${APP_NAME}/${COMPONENT_NAME}=${GIT_COMMIT} \
+    --set-template-ref ${COMPONENT_NAME}=${GIT_COMMIT} \
     --set-image-tag ${IMAGE}=${IMAGE_TAG} \
     --namespace ${NAMESPACE} \
     --timeout ${DEPLOY_TIMEOUT} \


### PR DESCRIPTION
Removes deprecated syntax used on cicd helper scripts for `set-template-ref` parameter