### PR TITLE
Initial commit to get bonfire working with ephemeral namespace operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,14 @@ When a tester is logged in using the proper account, namespace commands can be u
 
 Use `bonfire namespace -h` to see a list of all available namespace commands.
 
+
+### NamespaceReservation CRD
+
+`bonfire` can also be used to perform create, extend, list, and delete operations on a new NamespaceReservation CRD. This is available in the ephemeral cluster and is currently 
+in an 'alpha' state while we test out the new ephemeral namespace operator.
+
+Use `bonfire reservation -h` to test it out.
+
 ### Namespace reconciler
 
 A separate cron job runs the `bonfire namespace reconcile` command every 2 minutes. This command does the following:

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -25,7 +25,12 @@ from bonfire.openshift import (
 )
 from bonfire.utils import FatalError, split_equals, find_what_depends_on
 from bonfire.local import get_local_apps
-from bonfire.processor import TemplateProcessor, process_clowd_env, process_iqe_cji, process_reservation
+from bonfire.processor import (
+    TemplateProcessor,
+    process_clowd_env,
+    process_iqe_cji,
+    process_reservation,
+)
 from bonfire.namespaces import (
     Namespace,
     get_namespaces,
@@ -1034,8 +1039,21 @@ def _cmd_apps_what_depends_on(
 
 
 @reservation.command("create")
-@click.option('--requester', '-r', prompt='Requester', type=str, help='Name of the user requesting a reservation')
-@click.option('--duration', '-d', prompt='Duration', type=str, default='1h', help='Duration of the reservation')
+@click.option(
+    '--requester',
+    '-r',
+    prompt='Requester',
+    type=str,
+    help='Name of the user requesting a reservation',
+)
+@click.option(
+    '--duration',
+    '-d',
+    prompt='Duration',
+    type=str,
+    default='1h',
+    help='Duration of the reservation',
+)
 @options(_timeout_option)
 def _create_new_reservation(requester, duration, timeout):
     def _err_handler(err):
@@ -1050,7 +1068,10 @@ def _create_new_reservation(requester, duration, timeout):
         try:
             res_name = res_config["items"][0]["metadata"]["name"]
         except (KeyError, IndexError):
-            raise Exception("error parsing name of Reservation from processed template, check Reservation template")
+            raise Exception(
+                "error parsing name of Reservation from processed template, " +
+                "check Reservation template"
+            )
 
         apply_config(None, list_resource=res_config)
 
@@ -1075,8 +1096,21 @@ def _create_new_reservation(requester, duration, timeout):
 
 
 @reservation.command("extend")
-@click.option('--requester', '-r', prompt='Requester', type=str, help='Name of the user requesting an extension')
-@click.option('--duration', '-d', prompt='Duration', type=str, default='1h', help='Duration of the extension')
+@click.option(
+    '--requester',
+    '-r',
+    prompt='Requester',
+    type=str,
+    help='Name of the user requesting an extension',
+)
+@click.option(
+    '--duration',
+    '-d',
+    prompt='Duration',
+    type=str,
+    default='1h',
+    help='Duration of the extension',
+)
 def _extend_reservation(requester, duration):
     def _err_handler(err):
         msg = f"reservation extension failed: {str(err)}"
@@ -1107,7 +1141,13 @@ def _extend_reservation(requester, duration):
 
 
 @reservation.command("delete")
-@click.option('--requester', '-r', prompt='Requester', type=str, help='Name of the user requesting an extension')
+@click.option(
+    '--requester',
+    '-r',
+    prompt='Requester',
+    type=str,
+    help='Name of the user requesting an extension',
+)
 def _delete_reservation(requester):
     def _err_handler(err):
         msg = f"reservation deletion failed: {str(err)}"

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -289,7 +289,7 @@ def _validate_reservation_duration(ctx, param, value):
     try:
         return validate_time_string(value)
     except ValueError:
-        raise click.BadParameter("duration should be in string format. Ex: '1h30m'")
+        raise click.BadParameter("expecting h/m/s string. Ex: '1h30m'")
 
 
 _app_source_options = [
@@ -1224,8 +1224,10 @@ def _delete_reservation(name, namespace, requester):
         res = get_reservation(name, namespace, requester)
         if res:
             _warn_before_delete()
-            log.info("deleting reservation '%s'", res["metadata"]["name"])
-            oc("delete", "reservation", res["metadata"]["name"])
+            res_name = res["metadata"]["name"]
+            log.info("deleting reservation '%s'", res_name)
+            oc("delete", "reservation", res_name)
+            log.info("reservation '%s' deleted", res_name)
         else:
             raise FatalError("Reservation lookup failed")
     except KeyboardInterrupt as err:
@@ -1240,10 +1242,6 @@ def _delete_reservation(name, namespace, requester):
     except Exception as err:
         log.exception("hit unexpected error!")
         _err_handler(err)
-    else:
-        log.info(
-            "reservation '%s' deleted", name
-        )
 
 
 @reservation.command("list")

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -1128,7 +1128,10 @@ def _create_new_reservation(bot, name, requester, duration, timeout):
         _err_handler(err)
     else:
         log.info(
-            "namespace '%s' is reserved by '%s' for '%s'", ns_name, res_config["items"][0]["spec"]["requester"], duration
+            "namespace '%s' is reserved by '%s' for '%s'",
+            ns_name,
+            res_config["items"][0]["spec"]["requester"],
+            duration,
         )
         click.echo(ns_name)
 
@@ -1237,8 +1240,8 @@ def _list_reservations(mine, requester):
         if mine:
             try:
                 requester = whoami()
-            except:
-                log.info("whoami returned an error - getting reservations for 'bonfire'") # minikube
+            except Exception:
+                log.info("whoami returned an error - getting reservations for 'bonfire'")  # minikube
                 requester = "bonfire"
             oc("get", "reservation", "--selector", f"requester={requester}")
         else:

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -1241,7 +1241,9 @@ def _list_reservations(mine, requester):
             try:
                 requester = whoami()
             except Exception:
-                log.info("whoami returned an error - getting reservations for 'bonfire'")  # minikube
+                log.info(
+                    "whoami returned an error - getting reservations for 'bonfire'"
+                )  # minikube
                 requester = "bonfire"
             oc("get", "reservation", "--selector", f"requester={requester}")
         else:

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -1125,7 +1125,6 @@ def _create_new_reservation(bot, name, requester, duration, timeout):
                 f"Reservation with name {name} already exists"
             )
 
-        print(duration)
         res_config = process_reservation(name, requester, duration)
 
         log.debug("processed reservation:\n%s", res_config)

--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -34,6 +34,7 @@ EPHEMERAL_CLUSTER_CLOWDENV_TEMPLATE = resource_filename(
 )
 DEFAULT_IQE_CJI_TEMPLATE = resource_filename("bonfire", "resources/default-iqe-cji.yaml")
 DEFAULT_CONFIG_DATA = resource_filename("bonfire", "resources/default_config.yaml")
+DEFAULT_RESERVATION_TEMPLATE = resource_filename("bonfire", "resources/reservation-template.yaml")
 
 LOCAL_GRAPHQL_URL = "http://localhost:4000/graphql"
 

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -732,3 +732,31 @@ def wait_on_cji(namespace, cji_name, timeout):
     waiter.wait_for_ready(remaining_time)
 
     return pod_name
+
+
+def wait_on_reservation(res_name, timeout):
+    log.info("waiting for reservation '%s' to get picked up by operator", res_name)
+
+    def _find_reservation():
+        res = get_json("reservation", name=res_name)
+        try:
+            return res["status"]["namespace"]
+        except (KeyError, IndexError):
+            return False
+    
+    ns_name, elapsed = wait_for(
+        _find_reservation, num_sec=timeout, message=f"wait for namespace to be owned by reservation '{res_name}'"
+    )
+    return ns_name
+
+
+def get_reservation_by_requester(requester):
+    log.info("Retrieving reservation for '%s'", requester)
+
+    all_res = get_json("reservation")
+
+    for res in all_res["items"]:
+        if res["spec"]["requester"] == requester:
+            return res
+    
+    return None

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -752,13 +752,21 @@ def wait_on_reservation(res_name, timeout):
     return ns_name
 
 
-def get_reservation_by_requester(requester):
-    log.info("Retrieving reservation for '%s'", requester)
+def get_reservation(name=None, namespace=None):
+    res = {}
+    if name or namespace:
+        log.info("Retrieving reservation")
+        res = get_json("reservation", name=name, namespace=namespace)
+    return res
+
+
+def check_for_existing_reservation(requester):
+    log.info("Checking for existing reservations for '%s'", requester)
 
     all_res = get_json("reservation")
 
     for res in all_res["items"]:
         if res["spec"]["requester"] == requester:
-            return res
-
-    return None
+            return True
+    
+    return False

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -752,14 +752,6 @@ def wait_on_reservation(res_name, timeout):
     return ns_name
 
 
-def get_reservation(name=None, namespace=None):
-    res = {}
-    if name or namespace:
-        log.info("Retrieving reservation")
-        res = get_json("reservation", name=name, namespace=namespace)
-    return res
-
-
 def check_for_existing_reservation(requester):
     log.info("Checking for existing reservations for '%s'", requester)
 
@@ -768,5 +760,28 @@ def check_for_existing_reservation(requester):
     for res in all_res["items"]:
         if res["spec"]["requester"] == requester:
             return True
+
+    return False
+
+
+def get_reservation(name=None, namespace=None, requester=None):
+    if name:
+        res = get_json("reservation", name=name)
+        return res if res else False
+    elif namespace:
+        all_res = get_json("reservation")
+        for res in all_res["items"]:
+            if res["status"]["namespace"] == namespace:
+                return res
+    elif requester:
+        all_res = get_json("reservation", label=f"requester={requester}")
+        numRes = len(all_res["items"])
+        if numRes == 0:
+            return False
+        elif numRes == 1:
+            return all_res["items"][0]
+        else:
+            log.info("Multiple reservations found for requester '%s'. Aborting.", requester)
+            return False
 
     return False

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -768,5 +768,5 @@ def check_for_existing_reservation(requester):
     for res in all_res["items"]:
         if res["spec"]["requester"] == requester:
             return True
-    
+
     return False

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -747,7 +747,7 @@ def wait_on_reservation(res_name, timeout):
     ns_name, elapsed = wait_for(
         _find_reservation,
         num_sec=timeout,
-        message=f"wait for namespace to be owned by reservation '{res_name}'",
+        message=f"waiting for namespace to be allocated to reservation '{res_name}'",
     )
     return ns_name
 

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -743,9 +743,11 @@ def wait_on_reservation(res_name, timeout):
             return res["status"]["namespace"]
         except (KeyError, IndexError):
             return False
-    
+
     ns_name, elapsed = wait_for(
-        _find_reservation, num_sec=timeout, message=f"wait for namespace to be owned by reservation '{res_name}'"
+        _find_reservation,
+        num_sec=timeout,
+        message=f"wait for namespace to be owned by reservation '{res_name}'",
     )
     return ns_name
 
@@ -758,5 +760,5 @@ def get_reservation_by_requester(requester):
     for res in all_res["items"]:
         if res["spec"]["requester"] == requester:
             return res
-    
+
     return None

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -136,7 +136,7 @@ def process_reservation(
     params = dict()
     params["DURATION"] = duration
     params["REQUESTER"] = requester
-    
+
     if extension:
         res = get_reservation_by_requester(requester)
         if res:

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -141,10 +141,10 @@ def process_reservation(
     if requester is None:
         try:
             requester = whoami()
-        except:
-            log.info("whoami returned an error - setting requester to 'bonfire'") # minikube
+        except Exception:
+            log.info("whoami returned an error - setting requester to 'bonfire'")  # minikube
             requester = "bonfire"
-    
+
     params["REQUESTER"] = requester
 
     processed_template = process_template(template_data, params=params)

--- a/bonfire/resources/reservation-template.yaml
+++ b/bonfire/resources/reservation-template.yaml
@@ -8,7 +8,9 @@ objects:
   kind: NamespaceReservation
   metadata:
     name: ${NAME}
-    extensionId: ${EXTENSIONID} 
+    extensionId: ${EXTENSIONID}
+    labels:
+      requester: ${REQUESTER}
   spec:
     duration: ${DURATION}
     requester: ${REQUESTER}

--- a/bonfire/resources/reservation-template.yaml
+++ b/bonfire/resources/reservation-template.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: default-reservation
+
+objects:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: NamespaceReservation
+  metadata:
+    name: ${NAME}
+    extensionId: ${EXTENSIONID} 
+  spec:
+    duration: ${DURATION}
+    requester: ${REQUESTER}
+
+parameters:
+- name: DURATION
+  required: true
+- name: REQUESTER
+  required: true
+- name: NAME
+  required: true
+- name: EXTENSIONID
+  description: ID used to indicate a new extension of an existing reservation
+  generate: expression
+  from: "[a-zA-Z0-9]{10}"

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -106,6 +106,16 @@ def split_equals(list_of_str, allow_null=False):
     return output
 
 
+def validate_time_string(time):
+    valid_time = re.compile(r"^((\d+)h)?((\d+)m)?((\d+)s)?$")
+    print(time)
+    if not valid_time.match(time):
+        raise ValueError(
+            f"invalid format for duration '{time}', must match: r'{valid_time.pattern}'"
+        )
+    return time
+
+
 class RepoFile:
     def __init__(self, host, org, repo, path, ref="master"):
         if host not in ["local", "github", "gitlab"]:

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -108,7 +108,6 @@ def split_equals(list_of_str, allow_null=False):
 
 def validate_time_string(time):
     valid_time = re.compile(r"^((\d+)h)?((\d+)m)?((\d+)s)?$")
-    print(time)
     if not valid_time.match(time):
         raise ValueError(
             f"invalid format for duration '{time}', must match: r'{valid_time.pattern}'"


### PR DESCRIPTION
Hey @bsquizz this PR adds a few bonfire commands to interact with the new NamespaceReservation CRD that the namespace operator uses. Wanted to go ahead and get some eyes on it to see if you like the direction. 

Added a new "reservation" command grouping that includes:
- create
- extend
- delete
- list

There's some duplicated code, but if you like the approach I can do a bit of refactoring/cleanup. Tried to adhere to existing patterns wherever possible. 