### PR TITLE
Remove fail_condition while waiting for pod

### DIFF
--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -715,7 +715,6 @@ def wait_on_cji(namespace, cji_name, timeout):
 
     pod_name, elapsed = wait_for(
         _pod_found,
-        fail_condition=None,
         num_sec=remaining_time,
         message=f"wait for Pod to appear owned by CJI '{cji_name}'",
     )


### PR DESCRIPTION
`_pod_found` return `False` not `None`. I think the `fail_condition` is not needed at all
```
15:12:53 2021-09-17 13:05:17 [    INFO] [          MainThread] waiting for Job to appear owned by CJI 'vmaas-smoke-tests'
15:12:53 2021-09-17 13:05:18 [    INFO] [          MainThread] found Job 'vmaas-smoke-tests-iqe' created by CJI 'vmaas-smoke-tests', now waiting for pod to appear
15:12:53 2021-09-17 13:05:18 [    INFO] [          MainThread] found pod 'False' associated with CJI 'vmaas-smoke-tests', now waiting for pod to be 'running'
15:12:53 2021-09-17 13:05:18 [   ERROR] [          MainThread] hit unexpected error!
15:12:53 Traceback (most recent call last):
15:12:53   File "/var/lib/jenkins/workspace/RedHatInsights-vmaas-pr-check/.bonfire_venv/lib64/python3.6/site-packages/bonfire/bonfire.py", line 939, in _cmd_deploy_iqe_cji
15:12:53     pod_name = wait_on_cji(namespace, cji_name, timeout)
15:12:53   File "/var/lib/jenkins/workspace/RedHatInsights-vmaas-pr-check/.bonfire_venv/lib64/python3.6/site-packages/bonfire/openshift.py", line 731, in wait_on_cji
15:12:53     waiter = ResourceWaiter(namespace, "pod", pod_name)
15:12:53   File "/var/lib/jenkins/workspace/RedHatInsights-vmaas-pr-check/.bonfire_venv/lib64/python3.6/site-packages/bonfire/openshift.py", line 384, in __init__
15:12:53     self.name = name.lower()
15:12:53 AttributeError: 'bool' object has no attribute 'lower'
15:12:53 ERROR: deploy failed: 'bool' object has no attribute 'lower'
```