### PR TITLE
Add variable to select IQE image on CJI script

### DIFF
--- a/cicd/cji_smoke_test.sh
+++ b/cicd/cji_smoke_test.sh
@@ -12,6 +12,7 @@
 # https://unix.stackexchange.com/questions/122845/using-a-b-for-variable-assignment-in-scripts/122848#122848
 : "${IQE_MARKER_EXPRESSION:='""'}"
 : "${IQE_FILTER_EXPRESSION:='""'}"
+: "${IQE_IMAGE_TAG:='""'}"
 
 CJI_NAME="$COMPONENT_NAME-smoke-tests"
 
@@ -21,7 +22,7 @@ if [[ -z $IQE_CJI_TIMEOUT ]]; then
 fi
 
 # Invoke the CJI using the options set via env vars
-pod=$(bonfire deploy-iqe-cji $COMPONENT_NAME -m "$IQE_MARKER_EXPRESSION" -k "$IQE_FILTER_EXPRESSION" -e "clowder_smoke" --cji-name $CJI_NAME -n $NAMESPACE)
+pod=$(bonfire deploy-iqe-cji $COMPONENT_NAME -m "$IQE_MARKER_EXPRESSION" -k "$IQE_FILTER_EXPRESSION" -e "clowder_smoke" --cji-name $CJI_NAME -n $NAMESPACE --image-tag "${IQE_IMAGE_TAG}")
 
 # Pipe logs to background to keep them rolling in jenkins
 oc logs -n $NAMESPACE $pod -f &


### PR DESCRIPTION
provides the `IQE_IMAGE_TAG` variable so you can set it on the `pr_check.sh` script to change the IQE image used (useful for testing MR changes for your IQE plugin)