### PR TITLE
Validate whether components provided in CLI options exist in config

### DIFF
--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -195,24 +195,16 @@ class TemplateProcessor:
 
         for path, value in data.items():
             split = path.split("/")
-            component_name = None
-            remaining_path = []
             if len(split) == max_len:
                 # first item was an app name
-                component_name = split[1]
-                try:
-                    remaining_path = split[2:]
-                except KeyError:
-                    pass
+                new_path = split[1:]
             elif len(split) == max_len - 1:
                 # first item was a component name
-                component_name = split[0]
-                try:
-                    remaining_path = split[1:]
-                except KeyError:
-                    pass
+                new_path = split[0:]
             else:
                 raise FatalError(f"invalid format for {name}: {path}={value}")
+
+            component_name = new_path[0]
 
             # Make sure component name actually exists in app config
             if component_name not in all_components:
@@ -220,10 +212,7 @@ class TemplateProcessor:
                     f"component given for {name} not found in app config: {component_name}"
                 )
 
-            key_path = [component_name]
-            key_path.extend(remaining_path)
-
-            key = "/".join(key_path)
+            key = "/".join(new_path)
             updated_data[key] = value
 
         # Update the paths

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -217,10 +217,12 @@ class RepoFile:
                     log.info("trying alternate: %s", refs_to_try[idx + 1])
                     continue
                 else:
-                    alts = ", ".join(self._alternate_refs[self.ref])
+                    alts_txt = ""
+                    if self.ref in self._alternate_refs:
+                        alts = ", ".join(self._alternate_refs[self.ref])
+                        alts_txt = f" and its alternates: {alts}"
                     raise Exception(
-                        f"failed to fetch git ref '{self.ref}' or any of its alternates: '{alts}',"
-                        " check logs for more details"
+                        f"git ref fetch failed for '{self.ref}'{alts_txt}, see logs for details"
                     )
 
         return response


### PR DESCRIPTION
If an app team gets the COMPONENT_NAME wrong in their pr_check.sh it can cause debugging headaches.

Bonfire should warn if --set-template-ref was used (or other CLI args that rely on component like --set-parameter) but the requested component name to perform the operation on wasn't found anywhere in the app configurations.

Example:

App team accidentally had COMPONENT_NAME="insights-results-aggregator-cleaner" 
and it should have been:
COMPONENT_NAME="insights-aggregator-cleaner" 

This PR adds validation checks to ensure the component name is valid for:
```
--set-template-ref
--set-parameter
--remove-resources
--no-remove-resources
--component
```

I moved the app_name/component_name "deprecated syntax translation" logic that was written for `--set-parameter` and `--set-template-ref` into a common function.

Also fixed a KeyError bug I came across related to downloading alternate refs