### PR TITLE
Memory max limit to request ratio per Pod is 2

### DIFF
--- a/cicd/iqe_pod/create_iqe_pod.py
+++ b/cicd/iqe_pod/create_iqe_pod.py
@@ -28,7 +28,7 @@ def _get_base_pod_cfg():
                     "name": "iqe-tests",
                     "resources": {
                         "limits": {"cpu": "1", "memory": "2Gi"},
-                        "requests": {"cpu": "500m", "memory": "512Mi"},
+                        "requests": {"cpu": "500m", "memory": "1Gi"},
                     },
                     "stdin": True,
                     "tty": True,


### PR DESCRIPTION
Fix:
```
Error from server (Forbidden): error when creating "STDIN": pods "iqe-tests" is forbidden: memory max limit to request ratio per Pod is 2, but provided ratio is 4
```