### PR TITLE
remove bash "set -x" flag

### DIFF
--- a/cicd/_common_deploy_logic.sh
+++ b/cicd/_common_deploy_logic.sh
@@ -11,7 +11,7 @@
 #GIT_COMMIT="abcd123defg456"  # full git commit hash of the PR being tested
 trap "teardown" EXIT ERR SIGINT SIGTERM
 
-set -ex
+set -e
 
 : ${COMPONENTS:=""}
 : ${COMPONENTS_W_RESOURCES:=""}

--- a/cicd/bootstrap.sh
+++ b/cicd/bootstrap.sh
@@ -1,4 +1,4 @@
-set -exv
+set -ev
 
 # log in to ephemeral cluster
 oc login --token=$OC_LOGIN_TOKEN --server=$OC_LOGIN_SERVER

--- a/cicd/build.sh
+++ b/cicd/build.sh
@@ -16,7 +16,7 @@
 #RH_REGISTRY_USER
 #RH_REGISTRY_TOKEN
 
-set -ex
+set -e
 
 function build {
     if [ ! -f "$APP_ROOT/$DOCKERFILE" ]; then


### PR DESCRIPTION
This change *removes* the existing "set -x" commands from the start of the cicd scripts.

Having "set -x" at the beginning of files that are expected to be sourced in by the build and PR check scripts for other services means that the job logs for those services are always extremely noisy. Furthermore, if the service developers don't realize that the noisy "print all commands" flag was set, secrets and credentials that are set in the service's own scripts may unknowingly be leaked into logs since all commands are being printed out. (This has actually been happening, leaking Red Hat QE's AWS and Azure credentials in smoke tests, much to our chagrin.)

I think it would be better for the sourced bonfire scripts to be quieter by default, as is the case for many shell commands in general. If the calling script in the service wants to get all the noise, they should be the one to "set -x" (or equivalent) as needed. Maybe in the future you could have these scripts look for some kind of "debug" or "verbose" flag before turning the noise up to 11.