### PR TITLE
Pass in requirements args as []string

### DIFF
--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -104,6 +104,10 @@ def process_iqe_cji(
     with template_path.open() as fp:
         template_data = yaml.safe_load(fp)
 
+    requirements = requirements.split(",") if requirements else []
+    requirements_priority = requirements_priority.split(",") if requirements_priority else []
+    test_importance = test_importance.split(",") if test_importance else []
+
     params = dict()
     params["DEBUG"] = str(debug).lower()
     params["MARKER"] = marker
@@ -112,9 +116,9 @@ def process_iqe_cji(
     params["IMAGE_TAG"] = image_tag
     params["NAME"] = cji_name or f"iqe-{str(uuid.uuid4()).split('-')[0]}"
     params["APP_NAME"] = clowd_app_name
-    params["REQUIREMENTS"] = requirements
-    params["REQUIREMENTS_PRIORITY"] = requirements_priority
-    params["TEST_IMPORTANCE"] = test_importance
+    params["REQUIREMENTS"] = json.dumps(requirements)
+    params["REQUIREMENTS_PRIORITY"] = json.dumps(requirements_priority)
+    params["TEST_IMPORTANCE"] = json.dumps(test_importance)
 
     processed_template = process_template(template_data, params=params)
 

--- a/bonfire/resources/default-iqe-cji.yaml
+++ b/bonfire/resources/default-iqe-cji.yaml
@@ -17,9 +17,9 @@ objects:
         marker: ${MARKER}
         filter: ${FILTER}
         dynaconfEnvName: ${ENV_NAME}
-        requirements: ${REQUIREMENTS}
-        requirementsPriority: ${REQUIREMENTS_PRIORITY}
-        testImportance: ${TEST_IMPORTANCE}
+        requirements: ${{REQUIREMENTS}}
+        requirementsPriority: ${{REQUIREMENTS_PRIORITY}}
+        testImportance: ${{TEST_IMPORTANCE}}
 
 parameters:
 - name: NAME
@@ -38,8 +38,8 @@ parameters:
   value: "clowder_smoke"
   required: true
 - name: REQUIREMENTS
-  value: ""
+  value: "[]"
 - name: REQUIREMENTS_PRIORITY
-  value: ""
+  value: "[]"
 - name: TEST_IMPORTANCE
-  value: ""
+  value: "[]"


### PR DESCRIPTION
The CJI requires that the `requirements`, `requirementsPriority`, and `testImportance` fields be of type `[]string` -- currently bonfire is passing in just a pure string and that leads to:

```
2021-10-13 21:12:10 [    INFO] [         pid-1740145]  |stderr| The ClowdJobInvocation "iqe-15efd88b" is invalid:
2021-10-13 21:12:10 [    INFO] [         pid-1740145]  |stderr| * spec.testing.iqe.requirements: Invalid value: "string": spec.testing.iqe.requirements in body must be of type array: "string"
2021-10-13 21:12:10 [    INFO] [         pid-1740145]  |stderr| * spec.testing.iqe.requirementsPriority: Invalid value: "string": spec.testing.iqe.requirementsPriority in body must be of type array: "string"
2021-10-13 21:12:10 [    INFO] [         pid-1740145]  |stderr| * spec.testing.iqe.testImportance: Invalid value: "string": spec.testing.iqe.testImportance in body must be of type array: "string"
```