### PR TITLE
Remove feature flags from eph env for now

### DIFF
--- a/bonfire/resources/ephemeral-cluster-clowdenvironment.yaml
+++ b/bonfire/resources/ephemeral-cluster-clowdenvironment.yaml
@@ -46,7 +46,7 @@ objects:
         privatePort: 10000
         mode: operator
       featureFlags:
-        mode: local
+        mode: none
       metrics:
         port: 9000
         path: "/metrics"


### PR DESCRIPTION
Instability in the ephemeral cluster has made this issue more relevant. Let's turn it off and debug while the cluster stabilizes.