### PR TITLE
Add command version to bonfire

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -1114,7 +1114,7 @@ def _cmd_deploy_iqe_cji(
 @main.command("version")
 def _cmd_version():
     """Print bonfire version"""
-    print("bonfire version " + __version__)
+    click.echo("bonfire version " + __version__)
 
 
 @config.command("write-default")


### PR DESCRIPTION
Usage:

```shell
$ bonfire version
bonfire version 2.15.2.dev1+gc6b306f
```

How the help will look-like:

```
$ bonfire
Usage: bonfire [OPTIONS] COMMAND [ARGS]...

Options:
  -d, --debug  Enable debug logging
  -h, --help   Show this message and exit.

Commands:
  apps             Show information about deployable apps
  config           Commands related to bonfire configuration
  deploy           Process app templates and deploy them to a cluster
  deploy-env       Process ClowdEnv template and deploy to a cluster
  deploy-iqe-cji   Process IQE CJI template, apply it, and wait for it to...
  namespace        Perform operations related to namespace reservation
  process          Fetch and process application templates
  process-env      Process ClowdEnv template and print output
  process-iqe-cji  Process IQE ClowdJobInvocation template and print output
  reservation      ALPHA: Perform operations related to the...
  version          Print bonfire version
```