### PR TITLE
Allows bonfire to deploy to an operator-created namespace

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -868,7 +868,12 @@ def _cmd_config_deploy(
 ):
     """Process app templates and deploy them to a cluster"""
     requested_ns = namespace
-    used_ns_reservation_system, ns = _get_target_namespace(duration, retries, requested_ns)
+    operator_reservation = get_reservation(namespace=requested_ns)
+
+    if not operator_reservation:
+        used_ns_reservation_system, ns = _get_target_namespace(duration, retries, requested_ns)
+    else:
+        used_ns_reservation_system, ns = False, requested_ns
 
     if import_secrets:
         import_secrets_from_dir(secrets_dir)

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -868,11 +868,15 @@ def _cmd_config_deploy(
 ):
     """Process app templates and deploy them to a cluster"""
     requested_ns = namespace
+
+    log.debug("checking if namespace has been reserved via ns operator...")
     operator_reservation = get_reservation(namespace=requested_ns)
 
     if not operator_reservation:
+        log.debug("no ns operator reservation found, using old ns reservation system")
         used_ns_reservation_system, ns = _get_target_namespace(duration, retries, requested_ns)
     else:
+        log.debug("found existing ns operator reservation")
         used_ns_reservation_system, ns = False, requested_ns
 
     if import_secrets:
@@ -1249,7 +1253,7 @@ def _extend_reservation(name, namespace, requester, duration):
     if not (name or namespace or requester):
         _err_handler(
             "To extend a reservation provide one of name, "
-            "namespace, or requester. See bonfire reservation extend -h"
+            "namespace, or requester. See 'bonfire reservation extend -h'"
         )
 
     try:
@@ -1292,7 +1296,7 @@ def _delete_reservation(name, namespace, requester):
     if not (name or namespace or requester):
         _err_handler(
             "To delete a reservation provide one of name, "
-            "namespace, or requester. See bonfire reservation delete -h"
+            "namespace, or requester. See 'bonfire reservation delete -h'"
         )
 
     try:

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -1246,6 +1246,12 @@ def _extend_reservation(name, namespace, requester, duration):
         msg = f"reservation extension failed: {str(err)}"
         _error(msg)
 
+    if not (name or namespace or requester):
+        _err_handler(
+            "To extend a reservation provide one of name, "
+            "namespace, or requester. See bonfire reservation extend -h"
+        )
+
     try:
         res = get_reservation(name, namespace, requester)
         if res:
@@ -1282,6 +1288,12 @@ def _delete_reservation(name, namespace, requester):
     def _err_handler(err):
         msg = f"reservation deletion failed: {str(err)}"
         _error(msg)
+
+    if not (name or namespace or requester):
+        _err_handler(
+            "To delete a reservation provide one of name, "
+            "namespace, or requester. See bonfire reservation delete -h"
+        )
 
     try:
         res = get_reservation(name, namespace, requester)


### PR DESCRIPTION
@bsquizz This small change will bypass the old reservation logic when providing a namespace that is attached to a namespace reservation object. If there's no reservation it'll continue as normal. This will allow deploys to work on the new namespaces, and provide a starting point to branch off and merge the two subcommand groups