### PR TITLE
Catch -/-- values passed into CLI for remove-resource/no-remove-resources

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -284,6 +284,10 @@ def _validate_resource_arguments(ctx, param, value):
         "remove_resources": "no_remove_resources",
         "no_remove_resources": "remove_resources",
     }
+    if any([val.startswith("-") for val in value]):
+        raise click.BadParameter(
+            "--remove-resources/--no-remove-resources requires a component name or keyword 'all'"
+        )
     if "all" in value and "all" in ctx.params.get(opposite_option[param.name], {}):
         raise click.BadParameter(
             "--remove-resources and --no-remove-resources can't be both set to 'all'"


### PR DESCRIPTION
If you accidentally do not pass a TEXT value to --no-remove-resources or --remove-resources, the next CLI option can get picked up as the 'value', e.g.:

```
$ bonfire process --no-remove-resources --clowd-env env-ephemeral-31 vulnerability
ERROR: unable to infer name of ClowdEnvironment if namespace not provided.  Please run with one of: --clowd-env or --namespace
```