### PR TITLE
Use docker for mc

### DIFF
--- a/cicd/_common_deploy_logic.sh
+++ b/cicd/_common_deploy_logic.sh
@@ -9,6 +9,8 @@
 # Env vars set by 'bootstrap.sh':
 #IMAGE_TAG="abcd123"  # image tag for the PR being tested
 #GIT_COMMIT="abcd123defg456"  # full git commit hash of the PR being tested
+#ARTIFACTS_DIR -- directory where test run artifacts are stored
+
 trap "teardown" EXIT ERR SIGINT SIGTERM
 
 set -e

--- a/cicd/_common_deploy_logic.sh
+++ b/cicd/_common_deploy_logic.sh
@@ -16,7 +16,7 @@ set -e
 : ${COMPONENTS:=""}
 : ${COMPONENTS_W_RESOURCES:=""}
 : ${DEPLOY_TIMEOUT:="300"}
-K8S_ARTIFACTS_DIR="$WORKSPACE/artifacts/k8s_artifacts/"
+K8S_ARTIFACTS_DIR="$ARTIFACTS_DIR/k8s_artifacts/"
 START_TIME=$(date +%s)
 TEARDOWN_RAN=0
 

--- a/cicd/bootstrap.sh
+++ b/cicd/bootstrap.sh
@@ -20,6 +20,9 @@ export BONFIRE_ROOT=${WORKSPACE}/bonfire
 export CICD_ROOT=${BONFIRE_ROOT}/cicd
 export IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 export GIT_COMMIT=$(git rev-parse HEAD)
+export ARTIFACTS_DIR="$WORKSPACE/artifacts"
+
+rm -fr $ARTIFACTS_DIR && mkdir -p $ARTIFACTS_DIR
 
 # TODO: create custom jenkins agent image that has a lot of this stuff pre-installed
 export LANG=en_US.utf-8

--- a/cicd/cji_smoke_test.sh
+++ b/cicd/cji_smoke_test.sh
@@ -73,11 +73,13 @@ export MINIO_PORT=$LOCAL_SVC_PORT
 # Setup the minio client to auth to the local eph minio in the ns
 echo "Fetching artifacts from minio..."
 
-docker run -ti --rm --net=host \
+CONTAINER_ID=$(docker run -ti --net=host \
     --entrypoint="/bin/sh" \
-    --mount type=bind,source="$(pwd)"/artifacts,target=/artifacts \
     $MC_IMAGE \
     -c "mc --no-color alias set minio http://${MINIO_HOST}:${MINIO_PORT} ${MINIO_ACCESS} ${MINIO_SECRET_KEY} && mc --no-color mirror --overwrite minio/${POD}-artifacts /artifacts/"
+)
+docker cp $CONTAINER_ID:/artifacts/. $WORKSPACE/artifacts
+docker rm $CONTAINER_ID
 
 echo "copied artifacts from iqe pod: "
 ls -l $WORKSPACE/artifacts

--- a/cicd/cji_smoke_test.sh
+++ b/cicd/cji_smoke_test.sh
@@ -79,8 +79,8 @@ mc --no-color alias set minio http://${MINIO_HOST}:${MINIO_PORT} ${MINIO_ACCESS}
 mc --no-color mirror --overwrite minio/${POD}-artifacts /artifacts/
 "
 docker run -ti --net=host --name=$CONTAINER_NAME --entrypoint="/bin/sh" $MC_IMAGE -c "$CMD"
-docker cp $CONTAINER_NAME:/artifacts/. $WORKSPACE/artifacts
+docker cp $CONTAINER_NAME:/artifacts/. $ARTIFACTS_DIR
 docker rm $CONTAINER_NAME
 
 echo "copied artifacts from iqe pod: "
-ls -l $WORKSPACE/artifacts
+ls -l $ARTIFACTS_DIR

--- a/cicd/cji_smoke_test.sh
+++ b/cicd/cji_smoke_test.sh
@@ -76,7 +76,7 @@ echo "Fetching artifacts from minio..."
 CONTAINER_ID=$(docker run -ti --net=host \
     --entrypoint="/bin/sh" \
     $MC_IMAGE \
-    -c "mc --no-color alias set minio http://${MINIO_HOST}:${MINIO_PORT} ${MINIO_ACCESS} ${MINIO_SECRET_KEY} && mc --no-color mirror --overwrite minio/${POD}-artifacts /artifacts/"
+    -c "mkdir -p /artifacts && mc --no-color alias set minio http://${MINIO_HOST}:${MINIO_PORT} ${MINIO_ACCESS} ${MINIO_SECRET_KEY} && mc --no-color mirror --overwrite minio/${POD}-artifacts /artifacts/"
 )
 docker cp $CONTAINER_ID:/artifacts/. $WORKSPACE/artifacts
 docker rm $CONTAINER_ID

--- a/cicd/cji_smoke_test.sh
+++ b/cicd/cji_smoke_test.sh
@@ -77,7 +77,7 @@ docker run -ti --rm \
     --entrypoint="/bin/sh" \
     --mount type=bind,source="$(pwd)"/artifacts,target=/artifacts \
     $MC_IMAGE \
-    "-c \"mc alias set minio http://${MINIO_HOST}:${MINIO_PORT} ${MINIO_ACCESS} ${MINIO_SECRET_KEY} && mc mirror --overwrite minio/${POD}-artifacts /artifacts/\""
+    -c "mc alias set minio http://${MINIO_HOST}:${MINIO_PORT} ${MINIO_ACCESS} ${MINIO_SECRET_KEY} && mc mirror --overwrite minio/${POD}-artifacts /artifacts/"
 
 echo "copied artifacts from iqe pod: "
 ls -l $WORKSPACE/artifacts

--- a/cicd/cji_smoke_test.sh
+++ b/cicd/cji_smoke_test.sh
@@ -73,11 +73,11 @@ export MINIO_PORT=$LOCAL_SVC_PORT
 # Setup the minio client to auth to the local eph minio in the ns
 echo "Fetching artifacts from minio..."
 
-docker run -ti --rm \
+docker run -ti --rm --net=host \
     --entrypoint="/bin/sh" \
     --mount type=bind,source="$(pwd)"/artifacts,target=/artifacts \
     $MC_IMAGE \
-    -c "mc alias set minio http://${MINIO_HOST}:${MINIO_PORT} ${MINIO_ACCESS} ${MINIO_SECRET_KEY} && mc mirror --overwrite minio/${POD}-artifacts /artifacts/"
+    -c "mc --no-color alias set minio http://${MINIO_HOST}:${MINIO_PORT} ${MINIO_ACCESS} ${MINIO_SECRET_KEY} && mc --no-color mirror --overwrite minio/${POD}-artifacts /artifacts/"
 
 echo "copied artifacts from iqe pod: "
 ls -l $WORKSPACE/artifacts

--- a/cicd/cji_smoke_test.sh
+++ b/cicd/cji_smoke_test.sh
@@ -20,6 +20,10 @@
 : "${IQE_REQUIREMENTS_PRIORITY:='""'}"
 : "${IQE_TEST_IMPORTANCE:='""'}"
 
+# minio client is used to fetch test artifacts from minio in the ephemeral ns
+MC_IMAGE="quay.io/cloudservices/mc:latest"
+docker pull $MC_IMAGE
+
 CJI_NAME="$COMPONENT_NAME-smoke-tests"
 
 if [[ -z $IQE_CJI_TIMEOUT ]]; then
@@ -29,7 +33,7 @@ fi
 
 # Invoke the CJI using the options set via env vars
 set -x
-pod=$(
+POD=$(
     bonfire deploy-iqe-cji $COMPONENT_NAME \
     --marker "$IQE_MARKER_EXPRESSION" \
     --filter "$IQE_FILTER_EXPRESSION" \
@@ -43,18 +47,13 @@ pod=$(
 set +x
 
 # Pipe logs to background to keep them rolling in jenkins
-oc logs -n $NAMESPACE $pod -f &
+oc logs -n $NAMESPACE $POD -f &
 
 # Wait for the job to Complete or Fail before we try to grab artifacts
 # condition=complete does trigger when the job fails
 set -x
 oc wait --timeout=$IQE_CJI_TIMEOUT --for=condition=JobInvocationComplete -n $NAMESPACE cji/$CJI_NAME
 set +x
-
-# Get the minio client
-# TODO: bake this into jenkins agent template
-curl https://dl.min.io/client/mc/release/linux-amd64/mc -o mc
-chmod +x mc
 
 # Set up port-forward for minio
 LOCAL_SVC_PORT=$(python -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
@@ -73,10 +72,11 @@ export MINIO_PORT=$LOCAL_SVC_PORT
 
 # Setup the minio client to auth to the local eph minio in the ns
 echo "Fetching artifacts from minio..."
-./mc alias set minio http://$MINIO_HOST:$MINIO_PORT $MINIO_ACCESS $MINIO_SECRET_KEY
 
-# "mirror" copies the entire artifacts dir from the pod and writes it to the jenkins node
-./mc mirror --overwrite minio/$pod-artifacts artifacts/
+docker run -ti --rm $MC_IMAGE \
+    --entrypoint="/bin/sh" \
+    --mount type=bind,source="$(pwd)"/artifacts,target=/artifacts \
+    "mc alias set minio http://${MINIO_HOST}:${MINIO_PORT} ${MINIO_ACCESS} ${MINIO_SECRET_KEY} && mc mirror --overwrite minio/${POD}-artifacts /artifacts/"
 
 echo "copied artifacts from iqe pod: "
 ls -l $WORKSPACE/artifacts

--- a/cicd/cji_smoke_test.sh
+++ b/cicd/cji_smoke_test.sh
@@ -73,9 +73,10 @@ export MINIO_PORT=$LOCAL_SVC_PORT
 # Setup the minio client to auth to the local eph minio in the ns
 echo "Fetching artifacts from minio..."
 
-docker run -ti --rm $MC_IMAGE \
+docker run -ti --rm \
     --entrypoint="/bin/sh" \
     --mount type=bind,source="$(pwd)"/artifacts,target=/artifacts \
+    $MC_IMAGE \
     "mc alias set minio http://${MINIO_HOST}:${MINIO_PORT} ${MINIO_ACCESS} ${MINIO_SECRET_KEY} && mc mirror --overwrite minio/${POD}-artifacts /artifacts/"
 
 echo "copied artifacts from iqe pod: "

--- a/cicd/cji_smoke_test.sh
+++ b/cicd/cji_smoke_test.sh
@@ -77,7 +77,7 @@ docker run -ti --rm \
     --entrypoint="/bin/sh" \
     --mount type=bind,source="$(pwd)"/artifacts,target=/artifacts \
     $MC_IMAGE \
-    "mc alias set minio http://${MINIO_HOST}:${MINIO_PORT} ${MINIO_ACCESS} ${MINIO_SECRET_KEY} && mc mirror --overwrite minio/${POD}-artifacts /artifacts/"
+    "-c \"mc alias set minio http://${MINIO_HOST}:${MINIO_PORT} ${MINIO_ACCESS} ${MINIO_SECRET_KEY} && mc mirror --overwrite minio/${POD}-artifacts /artifacts/\""
 
 echo "copied artifacts from iqe pod: "
 ls -l $WORKSPACE/artifacts

--- a/cicd/examples/unit_test_example.sh
+++ b/cicd/examples/unit_test_example.sh
@@ -21,8 +21,8 @@ source .bonfire_venv/bin/activate
 
 # If your unit tests store junit xml results, you should store them in a file matching format `artifacts/junit-*.xml`
 # If you have no junit file, use the below code to create a 'dummy' result file so Jenkins will not fail
-mkdir -p $WORKSPACE/artifacts
-cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
+mkdir -p $ARTIFACTS_DIR
+cat << EOF > $ARTIFACTS_DIR/junit-dummy.xml
 <testsuite tests="1">
     <testcase classname="dummy" name="dummytest"/>
 </testsuite>

--- a/cicd/examples/unit_test_example_ephemeral_db.sh
+++ b/cicd/examples/unit_test_example_ephemeral_db.sh
@@ -24,8 +24,8 @@ source .bonfire_venv/bin/activate
 
 # If your unit tests store junit xml results, you should store them in a file matching format `artifacts/junit-*.xml`
 # If you have no junit file, use the below code to create a 'dummy' result file so Jenkins will not fail
-mkdir -p $WORKSPACE/artifacts
-cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
+mkdir -p $ARTIFACTS_DIR
+cat << EOF > $ARTIFACTS_DIR/junit-dummy.xml
 <testsuite tests="1">
     <testcase classname="dummy" name="dummytest"/>
 </testsuite>

--- a/cicd/smoke_test.sh
+++ b/cicd/smoke_test.sh
@@ -6,6 +6,9 @@
 #IQE_FILTER_EXPRESSION="something AND something_else" -- pytest filter, can be "" if no filter desired
 #NAMESPACE="mynamespace" -- namespace to deploy iqe pod into, can be set by 'deploy_ephemeral_env.sh'
 
+# Env vars set by 'bootstrap.sh':
+#ARTIFACTS_DIR -- directory where test run artifacts are stored
+
 IQE_POD_NAME="iqe-tests"
 
 # create a custom svc acct for the iqe pod to run with that has elevated permissions

--- a/cicd/smoke_test.sh
+++ b/cicd/smoke_test.sh
@@ -26,7 +26,7 @@ python $CICD_ROOT/iqe_pod/create_iqe_pod.py $NAMESPACE \
 oc cp -n $NAMESPACE $CICD_ROOT/iqe_pod/iqe_runner.sh $IQE_POD_NAME:/iqe_venv/iqe_runner.sh
 oc exec $IQE_POD_NAME -n $NAMESPACE -- bash /iqe_venv/iqe_runner.sh
 
-oc cp -n $NAMESPACE $IQE_POD_NAME:artifacts/ $WORKSPACE/artifacts
+oc cp -n $NAMESPACE $IQE_POD_NAME:artifacts/ $ARTIFACTS_DIR
 
 echo "copied artifacts from iqe pod: "
-ls -l $WORKSPACE/artifacts
+ls -l $ARTIFACTS_DIR


### PR DESCRIPTION
Since we ran into issues download the mc client with `curl`, now we will docker pull the image from a quay.io mirror and run mc that way.