### PR TITLE
Tag PR images differently to prevent accidental prod deploy

### DIFF
--- a/cicd/bootstrap.sh
+++ b/cicd/bootstrap.sh
@@ -19,6 +19,17 @@ export WORKSPACE=${WORKSPACE:-$APP_ROOT}  # if running in jenkins, use the build
 export BONFIRE_ROOT=${WORKSPACE}/bonfire
 export CICD_ROOT=${BONFIRE_ROOT}/cicd
 export IMAGE_TAG=$(git rev-parse --short=7 HEAD)
+
+# if this is a PR, use a different tag, since PR tags expire
+if [ ! -z "$ghprbPullId" ]; then
+  export IMAGE_TAG="pr-${ghprbPullId}-${IMAGE_TAG}"
+fi
+
+if [ ! -z "$gitlabMergeRequestIid" ]; then
+  export IMAGE_TAG="pr-${gitlabMergeRequestIid}-${IMAGE_TAG}"
+fi
+
+
 export GIT_COMMIT=$(git rev-parse HEAD)
 export ARTIFACTS_DIR="$WORKSPACE/artifacts"
 

--- a/cicd/build.sh
+++ b/cicd/build.sh
@@ -24,7 +24,10 @@ function build {
         exit 1
     fi
 
-    echo "LABEL quay.expires-after=3d" >> $APP_ROOT/$DOCKERFILE  # tag expires in 3 days
+    # if this is a PR, set the tag to expire in 3 days
+    if [ ! -z "$ghprbPullId" ] || [ ! -z "$gitlabMergeRequestIid" ]; then
+        echo "LABEL quay.expires-after=3d" >> $APP_ROOT/$DOCKERFILE
+    fi
 
     if test -f /etc/redhat-release && grep -q -i "release 7" /etc/redhat-release; then
         # on RHEL7, use docker


### PR DESCRIPTION
If we detect the scripts are running as part of a Jenkins job for a PR, we will tag the image as `pr-<pr id>-<first 7 chars of commit sha>`