### PR TITLE
Add logic to retry mc artifact copy

### DIFF
--- a/cicd/_common_deploy_logic.sh
+++ b/cicd/_common_deploy_logic.sh
@@ -66,6 +66,9 @@ function collect_k8s_artifacts {
 
 function teardown {
     [ "$TEARDOWN_RAN" -ne "0" ] && return
+    echo "------------------------"
+    echo "----- TEARING DOWN -----"
+    echo "------------------------"
     if [ ! -z "$NAMESPACE" ]; then
         set +e
         collect_k8s_artifacts

--- a/cicd/cji_smoke_test.sh
+++ b/cicd/cji_smoke_test.sh
@@ -98,12 +98,20 @@ run_mc () {
 }
 
 # Add retry logic for intermittent minio connection failures
-FINAL_RETCODE=1
+MINIO_SUCCESS=false
 for i in $(seq 1 5); do
-    run_mc && FINAL_RETCODE=0 break || echo "WARNING: minio artifact copy failed, retrying in 5sec..."; sleep 5
+    if run_mc; then
+        MINIO_SUCCESS=true
+        break
+    else
+        if [ "$i" -lt "5"]; then
+            echo "WARNING: minio artifact copy failed, retrying in 5sec..."
+            sleep 5
+        fi
+    fi
 done
 
-if [ "$FINAL_RETCODE" -gt "0" ]; then
+if [ "$MINIO_SUCCESS" = false ]; then
     echo "ERROR: minio artifact copy failed"
     exit 1
 fi

--- a/cicd/cji_smoke_test.sh
+++ b/cicd/cji_smoke_test.sh
@@ -89,7 +89,8 @@ run_mc () {
     echo "running: docker run -t --net=host --name=$CONTAINER_NAME --entrypoint=\"/bin/sh\" $MC_IMAGE -c \"$CMD\""
     set +e
     docker run -t --net=host --name=$CONTAINER_NAME --entrypoint="/bin/sh" $MC_IMAGE -c "$CMD"
-    RET_CODE=$?
+    # temp...
+    RET_CODE=1
     docker cp $CONTAINER_NAME:/artifacts/. $ARTIFACTS_DIR
     docker rm $CONTAINER_NAME
     set -e

--- a/cicd/cji_smoke_test.sh
+++ b/cicd/cji_smoke_test.sh
@@ -104,7 +104,7 @@ for i in $(seq 1 5); do
         MINIO_SUCCESS=true
         break
     else
-        if [ "$i" -lt "5"]; then
+        if [ "$i" -lt "5" ]; then
             echo "WARNING: minio artifact copy failed, retrying in 5sec..."
             sleep 5
         fi

--- a/cicd/cji_smoke_test.sh
+++ b/cicd/cji_smoke_test.sh
@@ -89,8 +89,7 @@ run_mc () {
     echo "running: docker run -t --net=host --name=$CONTAINER_NAME --entrypoint=\"/bin/sh\" $MC_IMAGE -c \"$CMD\""
     set +e
     docker run -t --net=host --name=$CONTAINER_NAME --entrypoint="/bin/sh" $MC_IMAGE -c "$CMD"
-    # temp...
-    RET_CODE=1
+    RET_CODE=$?
     docker cp $CONTAINER_NAME:/artifacts/. $ARTIFACTS_DIR
     docker rm $CONTAINER_NAME
     set -e

--- a/cicd/cji_smoke_test.sh
+++ b/cicd/cji_smoke_test.sh
@@ -98,9 +98,15 @@ run_mc () {
 }
 
 # Add retry logic for intermittent minio connection failures
+FINAL_RETCODE=1
 for i in $(seq 1 5); do
-    run_mc && break || echo "WARNING: minio artifact copy failed, retrying in 5sec..."; sleep 5
+    run_mc && FINAL_RETCODE=0 break || echo "WARNING: minio artifact copy failed, retrying in 5sec..."; sleep 5
 done
+
+if [ "$FINAL_RETCODE" -gt "0" ]; then
+    echo "ERROR: minio artifact copy failed"
+    exit 1
+fi
 
 echo "copied artifacts from iqe pod: "
 ls -l $ARTIFACTS_DIR


### PR DESCRIPTION
We had a pr check hit a 'connection refused' error when copying artifacts from minio:
```
11:19:48 Fetching artifacts from minio...
11:19:53 mc: <ERROR> Unable to initialize new alias from the provided credentials. Get "http://localhost:34977/probe-bucket-sign-9nwmg31wt23i/?location=": dial tcp 127.0.0.1:34977: connect: connection refused.
11:19:53 Forwarding from 127.0.0.1:34977 -> 9000 
```

This adds some retry logic in case that was an intermittent blip