### PR TITLE
using unique requester when setting up ephemeral db

### DIFF
--- a/cicd/deploy_ephemeral_db.sh
+++ b/cicd/deploy_ephemeral_db.sh
@@ -8,7 +8,8 @@ source ${CICD_ROOT}/_common_deploy_logic.sh
 DB_DEPLOYMENT_NAME="${DB_DEPLOYMENT_NAME:-$COMPONENT_NAME-db}"
 
 # Deploy k8s resources for app without its dependencies
-NAMESPACE=$(bonfire namespace reserve)
+BONFIRE_NS_REQUESTER_DB="$BONFIRE_NS_REQUESTER-db"
+NAMESPACE=$(bonfire namespace reserve -r $BONFIRE_NS_REQUESTER_DB)
 # TODO: add code to bonfire to deploy an app if it is defined in 'sharedAppDbName' on the ClowdApp
 # TODO: add a bonfire command to deploy just an app's DB
 set -x


### PR DESCRIPTION
@bsquizz anything else required here? Using the same requester name set up in bootstrap.sh and appending "db". I didn't want to re-export the requester since env deployment also uses it