### PR TITLE
fail with FatalError if reserved ns is empty string

### DIFF
--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -264,6 +264,8 @@ def reserve_namespace(name, requester, duration, timeout, local=True):
         requester,
         duration,
     )
+    if not ns_name:
+        raise FatalError("Reservation of namespace failed.")
 
     return Namespace(name=ns_name)
 


### PR DESCRIPTION
when ns operator is not working properly it can happen that it returns ns with name `''`
```
{'apiVersion': 'cloud.redhat.com/v1alpha1',
 'kind': 'NamespaceReservation',
 'metadata': {'annotations': {'kubectl.kubernetes.io/last-applied-configuration': '{"apiVersion":"cloud.redhat.com/v1alpha1","kind":"NamespaceReservation","metadata":{"annotations":{},"labels":{"requester":"psegedy"},"name":"bonfire-reservation-508bc141"},"spec":{"duration":"1h","requester":"psegedy"}}\n'},
  'creationTimestamp': '2022-01-13T14:58:50Z',
  'generation': 1,
  'labels': {'requester': 'psegedy'},
  'name': 'bonfire-reservation-508bc141',
  'resourceVersion': '644150572',
  'uid': '69fab39b-824d-412a-a626-6b7207f10d58'},
 'spec': {'duration': '1h', 'requester': 'psegedy'},
 'status': {'expiration': '2022-01-13T15:58:50Z',
  'namespace': '',
  'state': 'waiting'}}
```

then `bonfire namespace reserve` will fail with 
```
ValueError: Namespace needs one of: "name", "namespace_data"
ERROR: namespace reserve: hit unexpected error: Namespace needs one of: "name", "namespace_data"
```
so I thought it would be better to return FatalError in this case