### PR TITLE
Initial support for deploying Frontend resources

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -430,6 +430,13 @@ _process_options = [
         type=str,
         multiple=True,
     ),
+    click.option(
+        "--frontends",
+        "-F",
+        help="Deploy frontends (default: false)",
+        type=bool,
+        default=False,
+    ),
     _local_option,
 ]
 
@@ -737,6 +744,7 @@ def _process(
     single_replicas,
     component_filter,
     local,
+    frontends
 ):
     apps_config = _get_apps_config(source, target_env, ref_env, local_config_path)
 
@@ -753,6 +761,7 @@ def _process(
         single_replicas,
         component_filter,
         local,
+        frontends,
     )
     return processor.process()
 
@@ -782,6 +791,7 @@ def _cmd_process(
     single_replicas,
     component_filter,
     local,
+    frontends,
 ):
     """Fetch and process application templates"""
     clowd_env = _get_env_name(namespace, clowd_env)
@@ -802,6 +812,7 @@ def _cmd_process(
         single_replicas,
         component_filter,
         local,
+        frontends,
     )
     print(json.dumps(processed_templates, indent=2))
 
@@ -898,6 +909,7 @@ def _cmd_config_deploy(
     import_secrets,
     secrets_dir,
     local,
+    frontends,
 ):
     """Process app templates and deploy them to a cluster"""
     if not has_clowder():
@@ -951,6 +963,7 @@ def _cmd_config_deploy(
             single_replicas,
             component_filter,
             local,
+            frontends,
         )
         log.debug("app configs:\n%s", json.dumps(apps_config, indent=2))
         if not apps_config["items"]:

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -744,7 +744,7 @@ def _process(
     single_replicas,
     component_filter,
     local,
-    frontends
+    frontends,
 ):
     apps_config = _get_apps_config(source, target_env, ref_env, local_config_path)
 

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -449,7 +449,10 @@ class TemplateProcessor:
                     break
 
             if frontend_found and not self.frontends:
-                log.info("ignoring component %s, user opted to disable frontend deployments")
+                log.info(
+                    "ignoring component %s, user opted to disable frontend deployments",
+                    component_name,
+                )
                 new_items = []
 
             if new_items:

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -466,7 +466,7 @@ class TemplateProcessor:
                     self._process_component("frontend-configs")
 
                 if self.get_dependencies:
-                    # recursively process components to add config for dependent apps to self.k8s_list
+                    # recursively process to add config for dependent apps to self.k8s_list
                     self._add_dependencies_to_config(component_name, new_items)
         else:
             log.debug("component %s already processed", component_name)

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -174,11 +174,15 @@ class RepoFile:
 
     def fetch(self):
         if self.host == "local":
-            return self._fetch_local()
+            result = self._fetch_local()
         if self.host == "github":
-            return self._fetch_github()
+            result = self._fetch_github()
         if self.host == "gitlab":
-            return self._fetch_gitlab()
+            result = self._fetch_gitlab()
+
+        self._session.close()
+
+        return result
 
     @cached_property
     def _gl_certfile(self):


### PR DESCRIPTION
* Adds '--frontends' to enable deployment of templates containing a Frontend resource (for now, this defaults to false)
* If we discover a template has a Frontend, we auto-add 'frontend-configs' as a dependency to deploy
* Also get rid of annoying 'unclosed connection' warnings by closing HTTP session in RepoFile after fetch() is called