### PR TITLE
use app name in cji smoke script

### DIFF
--- a/cicd/cji_smoke_test.sh
+++ b/cicd/cji_smoke_test.sh
@@ -39,7 +39,7 @@ fi
 # Invoke the CJI using the options set via env vars
 set -x
 POD=$(
-    bonfire deploy-iqe-cji $COMPONENT_NAME \
+    bonfire deploy-iqe-cji $APP_NAME \
     --marker "$IQE_MARKER_EXPRESSION" \
     --filter "$IQE_FILTER_EXPRESSION" \
     --image-tag "${IQE_IMAGE_TAG}" \


### PR DESCRIPTION
Most of the services use the same name for component and app folders.
in the case of ros service; we are facing a problem.

With a first look, I think it should be the app name, not the component name.
but I'm not aware of the overall implementation. I'm worried; it should not break other services. 

I think another option is to rename resourceTemplates name as. `ros` .