### PR TITLE
add a script to post test run IDs

### DIFF
--- a/cicd/examples/pr_check_template.sh
+++ b/cicd/examples/pr_check_template.sh
@@ -52,7 +52,12 @@ source $CICD_ROOT/deploy_ephemeral_env.sh
 # will control the behavior of the test.
 #source $CICD_ROOT/smoke_test.sh
 
-# Run somke tests using a ClowdJobInvocation (preferred)
+# Run smoke tests using a ClowdJobInvocation (preferred)
 # The contents of this script can be found at:
 # https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd/cji_smoke_test.sh
 source $CICD_ROOT/cji_smoke_test.sh
+
+# Post a comment with test run IDs to the PR
+# The contents of this script can be found at:
+# https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd/post_test_results.sh
+source $CICD_ROOT/post_test_results.sh

--- a/cicd/post_test_results.sh
+++ b/cicd/post_test_results.sh
@@ -16,6 +16,8 @@ then
   done
 
   # post the comment
+  # set +e so that if this POST fails, the entire run will not fail
+  set +e
   curl \
     -X POST \
     -H "Accept: application/vnd.github.v3+json" \
@@ -23,6 +25,7 @@ then
     -H "Content-Type: application/json; charset=utf-8" \
     ${GITHUB_API_URL}/repos/${ghprbGhRepository}/issues/${ghprbPullId}/comments \
     -d "{\"body\":\"$message\"}"
+  set -e
 fi
 
 echo "end of posting test results"

--- a/cicd/post_test_results.sh
+++ b/cicd/post_test_results.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# starting the script
+echo "Posting test results"
+
+# getting archives uuids
+UUIDS="$(ls $ARTIFACTS_DIR | grep .tar.gz | sed -e 's/\.tar.gz$//')"
+
+if [[ -n $UUIDS ]]
+then
+  # construct the comment message
+  message="Test results are available in [Ibutsu](https://url.corp.redhat.com/ibutsu-runs). The test run IDs are:"
+  for uuid in $UUIDS
+  do
+    message="${message}\n${uuid}"
+  done
+
+  # post the comment
+  curl \
+    -X POST \
+    -H "Accept: application/vnd.github.v3+json" \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    -H "Content-Type: application/json; charset=utf-8" \
+    ${GITHUB_API_URL}/repos/${ghprbGhRepository}/issues/${ghprbPullId}/comments \
+    -d "{\"body\":\"$message\"}"
+fi
+
+echo "end of posting test results"


### PR DESCRIPTION
The result of this change is demonstrated here https://github.com/RedHatInsights/drift-backend/pull/332#issuecomment-1094599435

The idea is that the following line is added to `pr_check.sh` after calling `cji_smoke_test.sh`

```
source $CICD_ROOT/post_test_results.sh
```

The link to Ibutsu is hidden according to the recommendation https://url.corp.redhat.com/4ebe1ab therefore not possible to make it dynamic (include the id in the URL). 