### PR TITLE
post comment for gitlab MR

### DIFF
--- a/cicd/post_test_results.sh
+++ b/cicd/post_test_results.sh
@@ -8,24 +8,52 @@ UUIDS="$(ls $ARTIFACTS_DIR | grep .tar.gz | sed -e 's/\.tar.gz$//')"
 
 if [[ -n $UUIDS ]]
 then
-  # construct the comment message
-  message="Test results are available in [Ibutsu](https://url.corp.redhat.com/ibutsu-runs). The test run IDs are:"
-  for uuid in $UUIDS
-  do
-    message="${message}\n${uuid}"
-  done
+  # if it is a GitHub PR
+  if [[ -n $ghprbPullId ]]; then
+    # construct the comment message for GitHub
+    message="Test results are available in [Ibutsu](https://url.corp.redhat.com/ibutsu-runs). The test run IDs are:"
+    for uuid in $UUIDS
+    do
+      message="${message}\n${uuid}"
+    done
 
-  # post the comment
-  # set +e so that if this POST fails, the entire run will not fail
-  set +e
-  curl \
-    -X POST \
-    -H "Accept: application/vnd.github.v3+json" \
-    -H "Authorization: token ${GITHUB_TOKEN}" \
-    -H "Content-Type: application/json; charset=utf-8" \
-    ${GITHUB_API_URL}/repos/${ghprbGhRepository}/issues/${ghprbPullId}/comments \
-    -d "{\"body\":\"$message\"}"
-  set -e
+    # set +e so that if this POST fails, the entire run will not fail
+    set +e
+
+    # post a comment to GitHub
+    curl \
+      -X POST \
+      -H "Accept: application/vnd.github.v3+json" \
+      -H "Authorization: token ${GITHUB_TOKEN}" \
+      -H "Content-Type: application/json; charset=utf-8" \
+      ${GITHUB_API_URL}/repos/${ghprbGhRepository}/issues/${ghprbPullId}/comments \
+      -d "{\"body\":\"$message\"}"
+    set -e
+  fi
+
+  # if it is a GitLab MR
+  if [[ -n $gitlabMergeRequestIid ]]; then
+    # construct the comment message for GitLab
+    message="Test results are available in Ibutsu:"
+    for uuid in $UUIDS
+    do
+      urls="${urls}${IBUTSU_URL}/runs/${uuid}\n"
+    done
+
+    message="${message}\n${urls}"
+
+    # set +e so that if this POST fails, the entire run will not fail
+    set +e
+
+    # post a comment to GitLab
+    curl \
+      -X POST \
+      -H "PRIVATE-TOKEN: ${GITLAB_TOKEN_IQE_BOT}" \
+      -H "Content-Type: application/json; charset=utf-8" \
+      ${GITLAB_HOST_IQE_BOT}/api/v4/projects/${gitlabTargetNamespace}%2F${gitlabTargetRepoName}/merge_requests/${gitlabMergeRequestIid}/notes \
+      -d "{\"body\":\"$message\"}" -v
+    set -e
+  fi
 fi
 
 echo "end of posting test results"


### PR DESCRIPTION
This is a modification for a `post_test_results.sh` script. It adds posting a comment to GitLab MR.

Tested in GitHub PR: https://github.com/RedHatInsights/drift-backend/pull/332
Tested in GitLab MR: https://url.corp.redhat.com/85cbec6

