### PR TITLE
Rhcloud 18846 use new labels annotations

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -210,7 +210,7 @@ _ns_reserve_options = [
     ),
     click.option(
         "--pool",
-        type=click.Choice(['default', 'minimal'], case_sensitive=False),
+        type=click.Choice(["default", "minimal"], case_sensitive=False),
         default="default",
         show_default=True,
         help="Specifies the pool type name.",

--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -310,7 +310,7 @@ def extend_namespace(namespace, duration, local=True):
         if res.get("status", {}).get("state") == "expired":
             log.error(
                 "The reservation for namespace %s has expired. Please reserve a new namespace",
-                res["env-status"]["namespace"],
+                res["status"]["namespace"],
             )
             return None
 

--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -74,7 +74,7 @@ class Namespace:
 
     @property
     def status(self):
-        return self.annotations.get("status", "false")
+        return self.annotations.get("env-status", "false")
 
     @property
     def reserved(self):
@@ -135,7 +135,7 @@ class Namespace:
             res = self.reservation  # note: using 'reservation' property defined below
             if res:
                 self.requester = res["spec"]["requester"]
-                self.expires = _parse_time(res["status"]["expiration"])
+                self.expires = _parse_time(res["env-status"]["expiration"])
         else:
             self.requester = None
             self.expires = None
@@ -168,7 +168,7 @@ class Namespace:
             log.debug("fetching reservation for ns '%s'", self.name)
             self._reservation = get_reservation(namespace=self.name)
 
-        if not self._reservation or not self._reservation.get("status"):
+        if not self._reservation or not self._reservation.get("env-status"):
             self._reservation = None
             log.warning("could not retrieve reservation details for ns: %s", self.name)
 
@@ -185,8 +185,8 @@ class Namespace:
         managed = len(self._clowdapps)
         ready = 0
         for app in self._clowdapps:
-            if "status" in app:
-                deployments = app["status"]["deployments"]
+            if "env-status" in app:
+                deployments = app["env-status"]["deployments"]
                 if deployments["managedDeployments"] == deployments["readyDeployments"]:
                     ready += 1
 
@@ -215,7 +215,7 @@ def get_namespaces(available=False, mine=False):
             app for app in all_clowdapps if app.get("metadata", {}).get("namespace") == ns_name
         ]
         reservation_data = [
-            res for res in all_res if res.get("status", {}).get("namespace") == ns_name
+            res for res in all_res if res.get("env-status", {}).get("namespace") == ns_name
         ]
         # ensure a non-None value is passed in for these kwargs since we have already
         # pre-fetched the data
@@ -300,10 +300,10 @@ def release_reservation(name=None, namespace=None, pool=None, local=True):
 def extend_namespace(namespace, duration, local=True):
     res = get_reservation(namespace=namespace)
     if res:
-        if res.get("status", {}).get("state") == "expired":
+        if res.get("env-status", {}).get("state") == "expired":
             log.error(
                 "The reservation for namespace %s has expired. Please reserve a new namespace",
-                res["status"]["namespace"],
+                res["env-status"]["namespace"],
             )
             return None
 

--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -192,8 +192,8 @@ class Namespace:
         managed = len(self._clowdapps)
         ready = 0
         for app in self._clowdapps:
-            if "env-status" in app:
-                deployments = app["env-status"]["deployments"]
+            if "status" in app:
+                deployments = app["status"]["deployments"]
                 if deployments["managedDeployments"] == deployments["readyDeployments"]:
                     ready += 1
 
@@ -307,7 +307,7 @@ def release_reservation(name=None, namespace=None, pool=None, local=True):
 def extend_namespace(namespace, duration, local=True):
     res = get_reservation(namespace=namespace)
     if res:
-        if res.get("env-status", {}).get("state") == "expired":
+        if res.get("status", {}).get("state") == "expired":
             log.error(
                 "The reservation for namespace %s has expired. Please reserve a new namespace",
                 res["env-status"]["namespace"],

--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -194,7 +194,7 @@ class Namespace:
         for app in self._clowdapps:
             if "env-status" in app:
                 deployments = app["env-status"]["deployments"]
-                if deployments["managedDeployments"] == deployments["readyDeployments"]:    
+                if deployments["managedDeployments"] == deployments["readyDeployments"]:
                     ready += 1
 
         return f"{ready}/{managed}"

--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -114,7 +114,7 @@ class Namespace:
 
     @property
     def ready(self):
-        return self.status == "ready"
+        return self.env_status == "ready"
 
     @property
     def available(self):
@@ -187,7 +187,7 @@ class Namespace:
         for app in self._clowdapps:
             if "env-status" in app:
                 deployments = app["env-status"]["deployments"]
-                if deployments["managedDeployments"] == deployments["readyDeployments"]:
+                if deployments["managedDeployments"] == deployments["readyDeployments"]:    
                     ready += 1
 
         return f"{ready}/{managed}"

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import functools
 import json
 import logging
@@ -258,7 +259,7 @@ def apply_config(namespace, list_resource):
         oc("apply", "-f", "-", "-n", namespace, _in=json.dumps(list_resource))
 
 
-def get_json(restype, name=None, label=None, namespace=None):
+def get_json(restype, name=None, label=None, namespace=None) -> dict:
     """
     Run 'oc get' for a given resource type/name/label and return the json output.
 
@@ -914,12 +915,12 @@ def on_k8s():
     return True
 
 
-def get_all_namespaces():
+def get_all_namespaces() -> list:
     if not on_k8s():
-        all_namespaces = get_json("project")["items"]
+        all_namespaces = get_json("project", label="operator-ns")["items"]
     else:
-        all_namespaces = get_json("namespace")["items"]
-
+        all_namespaces = get_json("namespace", label="operator-ns")["items"]
+    
     return all_namespaces
 
 

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -259,7 +259,7 @@ def apply_config(namespace, list_resource):
         oc("apply", "-f", "-", "-n", namespace, _in=json.dumps(list_resource))
 
 
-def get_json(restype, name=None, label=None, namespace=None) -> dict:
+def get_json(restype, name=None, label=None, namespace=None):
     """
     Run 'oc get' for a given resource type/name/label and return the json output.
 
@@ -915,7 +915,7 @@ def on_k8s():
     return True
 
 
-def get_all_namespaces() -> list:
+def get_all_namespaces():
     if not on_k8s():
         all_namespaces = get_json("project", label="operator-ns")["items"]
     else:

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -920,7 +920,7 @@ def get_all_namespaces() -> list:
         all_namespaces = get_json("project", label="operator-ns")["items"]
     else:
         all_namespaces = get_json("namespace", label="operator-ns")["items"]
-    
+
     return all_namespaces
 
 

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import functools
 import json
 import logging

--- a/tests/data/namespace_data.json
+++ b/tests/data/namespace_data.json
@@ -5,9 +5,12 @@
                 "name": "namespace-1",
                 "namespace": "namspace-1",
                 "annotations": {
-                    "status": "false",
+                    "env-status": "false",
                     "operator-ns": "true",
                     "reserved": "true"
+                },
+                "labels": {
+                    "operator-ns": "true"
                 }
             },
             "status": {
@@ -19,9 +22,12 @@
                 "name": "namespace-2",
                 "namespace": "namspace-2",
                 "annotations": {
-                    "status": "false",
+                    "env-status": "false",
                     "operator-ns": "true",
                     "reserved": "true"
+                },
+                "labels": {
+                    "operator-ns": "true"
                 }
             },
             "status": {
@@ -33,9 +39,12 @@
                 "name": "namespace-3",
                 "namespace": "namspace-3",
                 "annotations": {
-                    "status": "ready",
+                    "env-status": "ready",
                     "operator-ns": "true",
                     "reserved": "false,"
+                },
+                "labels": {
+                    "operator-ns": "true"
                 }
             },
             "status": {
@@ -47,9 +56,12 @@
                 "name": "namespace-4",
                 "namespace": "namspace-4",
                 "annotations": {
-                    "status": "ready",
+                    "env-status": "ready",
                     "operator-ns": "true",
                     "reserved": "false,"
+                },
+                "labels": {
+                    "operator-ns": "true"
                 }
             },
             "status": {
@@ -61,9 +73,12 @@
                 "name": "namespace-5",
                 "namespace": "namespace-5",
                 "annotations": {
-                    "status": "false",
+                    "env-status": "false",
                     "operator-ns": "true",
                     "reserved": "true"
+                },
+                "labels": {
+                    "operator-ns": "true"
                 }
             },
             "status": {

--- a/tests/data/namespace_data.json
+++ b/tests/data/namespace_data.json
@@ -6,7 +6,6 @@
                 "namespace": "namspace-1",
                 "annotations": {
                     "env-status": "false",
-                    "operator-ns": "true",
                     "reserved": "true"
                 },
                 "labels": {
@@ -23,7 +22,6 @@
                 "namespace": "namspace-2",
                 "annotations": {
                     "env-status": "false",
-                    "operator-ns": "true",
                     "reserved": "true"
                 },
                 "labels": {
@@ -40,7 +38,6 @@
                 "namespace": "namspace-3",
                 "annotations": {
                     "env-status": "ready",
-                    "operator-ns": "true",
                     "reserved": "false,"
                 },
                 "labels": {
@@ -57,7 +54,6 @@
                 "namespace": "namspace-4",
                 "annotations": {
                     "env-status": "ready",
-                    "operator-ns": "true",
                     "reserved": "false,"
                 },
                 "labels": {
@@ -74,7 +70,6 @@
                 "namespace": "namespace-5",
                 "annotations": {
                     "env-status": "false",
-                    "operator-ns": "true",
                     "reserved": "true"
                 },
                 "labels": {

--- a/tests/test_bonfire.py
+++ b/tests/test_bonfire.py
@@ -16,15 +16,10 @@ def namespace_list():
 
 
 @pytest.fixture(scope="module")
-<<<<<<< HEAD
-def reservation_list() -> list:
-    with open(DATA_PATH.joinpath("reservation_data.json"), "r") as reservation_data_file:
-=======
 def reservation_list():
     with open(
         DATA_PATH.joinpath("reservation_data.json"), "r"
     ) as reservation_data_file:
->>>>>>> ea7ab2d (Removed function return types.)
         return json.load(reservation_data_file)["items"]
 
 

--- a/tests/test_bonfire.py
+++ b/tests/test_bonfire.py
@@ -10,14 +10,21 @@ DATA_PATH = Path(__file__).parent.joinpath("data")
 
 
 @pytest.fixture(scope="module")
-def namespace_list() -> list:
+def namespace_list():
     with open(DATA_PATH.joinpath("namespace_data.json"), "r") as namespace_data_file:
         return json.load(namespace_data_file)["items"]
 
 
 @pytest.fixture(scope="module")
+<<<<<<< HEAD
 def reservation_list() -> list:
     with open(DATA_PATH.joinpath("reservation_data.json"), "r") as reservation_data_file:
+=======
+def reservation_list():
+    with open(
+        DATA_PATH.joinpath("reservation_data.json"), "r"
+    ) as reservation_data_file:
+>>>>>>> ea7ab2d (Removed function return types.)
         return json.load(reservation_data_file)["items"]
 
 

--- a/tests/test_bonfire.py
+++ b/tests/test_bonfire.py
@@ -117,8 +117,6 @@ def test_ns_list_option(mocker, caplog, namespace_list: list, reservation_list: 
 
     actual = " ".join(result.output.split())
 
-    print(result.output)
-
     assert " ".join(["namespace-1", "true", "false", "none", "user-1"]) in actual
     assert " ".join(["namespace-2", "true", "false", "none", "user-2"]) in actual
     assert " ".join(["namespace-3", "false", "ready", "none"]) in actual
@@ -142,8 +140,6 @@ def test_ns_list_options_available(mocker, caplog, namespace_list: list, reserva
 
     actual = " ".join(result.output.split())
 
-    print(result.output)
-    
     assert " ".join(["namespace-1", "true", "false", "none", "user-1"]) not in actual
     assert " ".join(["namespace-2", "true", "false", "none", "user-2"]) not in actual
     assert " ".join(["namespace-3", "false", "ready", "none"]) in actual
@@ -166,8 +162,6 @@ def test_ns_list_option_mine(mocker, caplog, namespace_list: list, reservation_l
     result = runner.invoke(bonfire.namespace, ["list", "--mine"])
 
     actual = " ".join(result.output.split())
-
-    print(result.output)
 
     assert " ".join(["namespace-1", "true", "false", "none", "user-1"]) in actual
     assert " ".join(["namespace-2", "true", "false", "none", "user-2"]) not in actual

--- a/tests/test_bonfire.py
+++ b/tests/test_bonfire.py
@@ -117,6 +117,8 @@ def test_ns_list_option(mocker, caplog, namespace_list: list, reservation_list: 
 
     actual = " ".join(result.output.split())
 
+    print(result.output)
+
     assert " ".join(["namespace-1", "true", "false", "none", "user-1"]) in actual
     assert " ".join(["namespace-2", "true", "false", "none", "user-2"]) in actual
     assert " ".join(["namespace-3", "false", "ready", "none"]) in actual
@@ -140,6 +142,8 @@ def test_ns_list_options_available(mocker, caplog, namespace_list: list, reserva
 
     actual = " ".join(result.output.split())
 
+    print(result.output)
+    
     assert " ".join(["namespace-1", "true", "false", "none", "user-1"]) not in actual
     assert " ".join(["namespace-2", "true", "false", "none", "user-2"]) not in actual
     assert " ".join(["namespace-3", "false", "ready", "none"]) in actual
@@ -162,6 +166,8 @@ def test_ns_list_option_mine(mocker, caplog, namespace_list: list, reservation_l
     result = runner.invoke(bonfire.namespace, ["list", "--mine"])
 
     actual = " ".join(result.output.split())
+
+    print(result.output)
 
     assert " ".join(["namespace-1", "true", "false", "none", "user-1"]) in actual
     assert " ".join(["namespace-2", "true", "false", "none", "user-2"]) not in actual

--- a/tests/test_bonfire.py
+++ b/tests/test_bonfire.py
@@ -17,9 +17,7 @@ def namespace_list():
 
 @pytest.fixture(scope="module")
 def reservation_list():
-    with open(
-        DATA_PATH.joinpath("reservation_data.json"), "r"
-    ) as reservation_data_file:
+    with open(DATA_PATH.joinpath("reservation_data.json"), "r") as reservation_data_file:
         return json.load(reservation_data_file)["items"]
 
 


### PR DESCRIPTION
- Switched "status" label to "env-status"
- get_all_namespaces() function filters by newly created label: "operator-ns"
- Added property for the Namespaces class in namespaces.py to get label.
- Removed "operator-ns" annotation.