### PR TITLE
replace spaces with dashes for the gitlab comment

### DIFF
--- a/cicd/post_test_results.sh
+++ b/cicd/post_test_results.sh
@@ -50,7 +50,7 @@ then
       -X POST \
       -H "PRIVATE-TOKEN: ${GITLAB_TOKEN_IQE_BOT}" \
       -H "Content-Type: application/json; charset=utf-8" \
-      ${GITLAB_HOST_IQE_BOT}/api/v4/projects/${gitlabTargetNamespace}%2F${gitlabTargetRepoName}/merge_requests/${gitlabMergeRequestIid}/notes \
+      ${GITLAB_HOST_IQE_BOT}/api/v4/projects/${gitlabMergeRequestTargetProjectId}/merge_requests/${gitlabMergeRequestIid}/notes \
       -d "{\"body\":\"$message\"}" -v
     set -e
   fi


### PR DESCRIPTION
If the repo name contains spaces, the link to post a comment becomes broken. Spaces are replaced with dashes.
Tested here https://url.corp.redhat.com/cf5d9b8
