### PR TITLE
Rhcloud 19304 unit tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
-}

--- a/tests/test_bonfire.py
+++ b/tests/test_bonfire.py
@@ -1,5 +1,5 @@
-from socket import timeout
 import pytest
+from unittest.mock import ANY
 from click.testing import CliRunner
 from pathlib import Path
 import json
@@ -257,4 +257,4 @@ def test_ns_reserve_flag_timeout(
     runner = CliRunner()
     runner.invoke(bonfire.namespace, ["reserve", "--timeout", timeout])
 
-    mock_wait_on_res.assert_called_once_with(user, timeout)
+    mock_wait_on_res.assert_called_once_with(ANY, timeout)

--- a/tests/test_bonfire.py
+++ b/tests/test_bonfire.py
@@ -249,7 +249,7 @@ def test_ns_reserve_flag_timeout(
     mocker.patch("bonfire.namespaces.whoami", return_value=user)
     mocker.patch("bonfire.bonfire.check_for_existing_reservation", return_value=False)
     mocker.patch("bonfire.namespaces.get_reservation", return_value=None)
-    mocker.patch("bonfire.namespaces.process_reservation", return_value=namespace)
+    mocker.patch("bonfire.namespaces.process_reservation")
     mocker.patch("bonfire.namespaces.apply_config")
 
     mock_wait_on_res = mocker.patch("bonfire.namespaces.wait_on_reservation")
@@ -257,4 +257,4 @@ def test_ns_reserve_flag_timeout(
     runner = CliRunner()
     runner.invoke(bonfire.namespace, ["reserve", "--timeout", timeout])
 
-    mock_wait_on_res.assert_called_once_with(namespace, timeout)
+    mock_wait_on_res.assert_called_once_with(user, timeout)

--- a/tests/test_bonfire.py
+++ b/tests/test_bonfire.py
@@ -182,23 +182,8 @@ def test_ns_list_option_mine(
     assert " ".join(["namespace-5", "true", "false", "none", "user-5"]) not in actual
 
 
-@pytest.mark.parametrize(
-    "namespace, data",
-    [
-        ("namespace-1", {"reserved": True, "status": "false", "requester": "user-1"}),
-        ("namespace-2", {"reserved": True, "status": "false", "requester": "user-2"}),
-        ("namespace-3", {"reserved": False, "status": "ready", "requester": None}),
-        ("namespace-4", {"reserved": False, "status": "ready", "requester": None}),
-        ("namespace-5", {"reserved": True, "status": "false", "requester": "user-5"}),
-    ],
-)
 def test_ns_list_option_output(
-    mocker,
-    caplog,
-    namespace_list: list,
-    reservation_list: list,
-    namespace: str,
-    data: dict,
+    mocker, caplog, namespace_list: list, reservation_list: list,
 ):
     caplog.set_level(100000)
 

--- a/tests/test_bonfire.py
+++ b/tests/test_bonfire.py
@@ -221,12 +221,6 @@ def test_ns_list_option_output(
     actual_ns_4 = json.loads(result.output).get("namespace-4")
     actual_ns_5 = json.loads(result.output).get("namespace-5")
 
-    print(actual_ns_1)
-    print(actual_ns_2)
-    print(actual_ns_3)
-    print(actual_ns_4)
-    print(actual_ns_5)
-
     assert {
         "reserved": True,
         "status": "false",

--- a/tests/test_bonfire.py
+++ b/tests/test_bonfire.py
@@ -192,31 +192,23 @@ def test_ns_list_flag_output(
     actual_ns_4 = json.loads(result.output).get("namespace-4")
     actual_ns_5 = json.loads(result.output).get("namespace-5")
 
-    assert {
-        "reserved": True,
-        "status": "false",
-        "requester": "user-1",
-    }.items() <= actual_ns_1.items()
-    assert {
-        "reserved": True,
-        "status": "false",
-        "requester": "user-2",
-    }.items() <= actual_ns_2.items()
-    assert {
-        "reserved": False,
-        "status": "ready",
-        "requester": None,
-    }.items() <= actual_ns_3.items()
-    assert {
-        "reserved": False,
-        "status": "ready",
-        "requester": None,
-    }.items() <= actual_ns_4.items()
-    assert {
-        "reserved": True,
-        "status": "false",
-        "requester": "user-5",
-    }.items() <= actual_ns_5.items()
+    del actual_ns_1["expires_in"]
+    del actual_ns_2["expires_in"]
+    del actual_ns_3["expires_in"]
+    del actual_ns_4["expires_in"]
+    del actual_ns_5["expires_in"]
+
+    test_items_1 = {"reserved": True, "status": "false", "requester": "user-1"}
+    test_items_2 = {"reserved": True, "status": "false", "requester": "user-2"}
+    test_items_3 = {"reserved": False, "status": "ready", "requester": None}
+    test_items_4 = {"reserved": False, "status": "ready", "requester": None}
+    test_items_5 = {"reserved": True, "status": "false", "requester": "user-5"}
+    
+    assert all([item in test_items_1.items() for item in actual_ns_1.items()])
+    assert all([item in test_items_2.items() for item in actual_ns_2.items()])
+    assert all([item in test_items_3.items() for item in actual_ns_3.items()])
+    assert all([item in test_items_4.items() for item in actual_ns_4.items()])
+    assert all([item in test_items_5.items() for item in actual_ns_5.items()])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_bonfire.py
+++ b/tests/test_bonfire.py
@@ -18,9 +18,7 @@ def namespace_list() -> list:
 
 @pytest.fixture(scope="module")
 def reservation_list() -> list:
-    with open(
-        DATA_PATH.joinpath("reservation_data.json"), "r"
-    ) as reservation_data_file:
+    with open(DATA_PATH.joinpath("reservation_data.json"), "r") as reservation_data_file:
         return json.load(reservation_data_file)["items"]
 
 
@@ -95,13 +93,9 @@ def test_ns_reserve_flag_duration(mocker, caplog, duration: str):
     runner.invoke(bonfire.namespace, ["reserve", "--duration", duration])
 
     if duration:
-        mock_process_reservation.assert_called_once_with(
-            None, "user-3", duration, local=True
-        )
+        mock_process_reservation.assert_called_once_with(None, "user-3", duration, local=True)
     else:
-        mock_process_reservation.assert_called_once_with(
-            None, "user-3", "1h", local=True
-        )
+        mock_process_reservation.assert_called_once_with(None, "user-3", "1h", local=True)
 
 
 def test_ns_list_option(mocker, caplog, namespace_list: list, reservation_list: list):
@@ -110,9 +104,7 @@ def test_ns_list_option(mocker, caplog, namespace_list: list, reservation_list: 
     mocker.patch("bonfire.bonfire.has_ns_operator", return_value=True)
     mocker.patch("bonfire.namespaces.get_all_namespaces", return_value=namespace_list)
     mocker.patch("bonfire.namespaces.get_json", return_value={})
-    mocker.patch(
-        "bonfire.namespaces.get_all_reservations", return_value=reservation_list
-    )
+    mocker.patch("bonfire.namespaces.get_all_reservations", return_value=reservation_list)
     mocker.patch("bonfire.namespaces.on_k8s", return_value=False)
     mocker.patch("bonfire.namespaces.whoami", return_value="user-1")
     mocker.patch("bonfire.openshift.process_template", return_value={})
@@ -129,17 +121,13 @@ def test_ns_list_option(mocker, caplog, namespace_list: list, reservation_list: 
     assert " ".join(["namespace-5", "true", "false", "none", "user-5"]) in actual
 
 
-def test_ns_list_flag_available(
-    mocker, caplog, namespace_list: list, reservation_list: list
-):
+def test_ns_list_flag_available(mocker, caplog, namespace_list: list, reservation_list: list):
     caplog.set_level(100000)
 
     mocker.patch("bonfire.bonfire.has_ns_operator", return_value=True)
     mocker.patch("bonfire.namespaces.get_all_namespaces", return_value=namespace_list)
     mocker.patch("bonfire.namespaces.get_json", return_value={})
-    mocker.patch(
-        "bonfire.namespaces.get_all_reservations", return_value=reservation_list
-    )
+    mocker.patch("bonfire.namespaces.get_all_reservations", return_value=reservation_list)
     mocker.patch("bonfire.namespaces.on_k8s", return_value=False)
     mocker.patch("bonfire.namespaces.whoami", return_value="user-1")
     mocker.patch("bonfire.openshift.process_template", return_value={})
@@ -156,17 +144,13 @@ def test_ns_list_flag_available(
     assert " ".join(["namespace-5", "true", "false", "none", "user-5"]) not in actual
 
 
-def test_ns_list_flag_mine(
-    mocker, caplog, namespace_list: list, reservation_list: list
-):
+def test_ns_list_flag_mine(mocker, caplog, namespace_list: list, reservation_list: list):
     caplog.set_level(100000)
 
     mocker.patch("bonfire.bonfire.has_ns_operator", return_value=True)
     mocker.patch("bonfire.namespaces.get_all_namespaces", return_value=namespace_list)
     mocker.patch("bonfire.namespaces.get_json", return_value={})
-    mocker.patch(
-        "bonfire.namespaces.get_all_reservations", return_value=reservation_list
-    )
+    mocker.patch("bonfire.namespaces.get_all_reservations", return_value=reservation_list)
     mocker.patch("bonfire.namespaces.on_k8s", return_value=False)
     mocker.patch("bonfire.namespaces.whoami", return_value="user-1")
     mocker.patch("bonfire.openshift.process_template", return_value={})
@@ -184,16 +168,17 @@ def test_ns_list_flag_mine(
 
 
 def test_ns_list_flag_output(
-    mocker, caplog, namespace_list: list, reservation_list: list,
+    mocker,
+    caplog,
+    namespace_list: list,
+    reservation_list: list,
 ):
     caplog.set_level(100000)
 
     mocker.patch("bonfire.bonfire.has_ns_operator", return_value=True)
     mocker.patch("bonfire.namespaces.get_all_namespaces", return_value=namespace_list)
     mocker.patch("bonfire.namespaces.get_json", return_value={})
-    mocker.patch(
-        "bonfire.namespaces.get_all_reservations", return_value=reservation_list
-    )
+    mocker.patch("bonfire.namespaces.get_all_reservations", return_value=reservation_list)
     mocker.patch("bonfire.namespaces.on_k8s", return_value=False)
     mocker.patch("bonfire.namespaces.whoami", return_value="user-1")
     mocker.patch("bonfire.openshift.process_template", return_value={})
@@ -241,9 +226,7 @@ def test_ns_list_flag_output(
         ("user-7", "namespace-7", 700),
     ],
 )
-def test_ns_reserve_flag_timeout(
-    mocker, caplog, user: str, namespace: str, timeout: int
-):
+def test_ns_reserve_flag_timeout(mocker, caplog, user: str, namespace: str, timeout: int):
     caplog.set_level(100000)
     mocker.patch("bonfire.bonfire.has_ns_operator", return_value=True)
     mocker.patch("bonfire.namespaces.whoami", return_value=user)

--- a/tests/test_bonfire.py
+++ b/tests/test_bonfire.py
@@ -203,7 +203,7 @@ def test_ns_list_flag_output(
     test_items_3 = {"reserved": False, "status": "ready", "requester": None}
     test_items_4 = {"reserved": False, "status": "ready", "requester": None}
     test_items_5 = {"reserved": True, "status": "false", "requester": "user-5"}
-    
+
     assert all([item in test_items_1.items() for item in actual_ns_1.items()])
     assert all([item in test_items_2.items() for item in actual_ns_2.items()])
     assert all([item in test_items_3.items() for item in actual_ns_3.items()])


### PR DESCRIPTION
Added two new unit tests to the test_bonfire.py file for the following commands: `bonfire namespace list --output` and `bonfire namespace reserve --timeout`
