### PR TITLE
[RHCLOUD-19972] - Allow new reservations if existing reservations don't have active namespaces

### DIFF
--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -296,10 +296,11 @@ def check_for_existing_reservation(requester):
     for res in get_all_reservations():
         res_state = res.get("status", {}).get("state")
         if res["spec"]["requester"] == requester and res_state == "active":
-            if get_json("namespace", res["status"]["namespace"]):
+            ns = res["status"]["namespace"]
+            if get_json("namespace", ns):
                 return True
             else:
-                log.info("a reservation was found for namespace '%s' which no longer exists", res["status"]["namespace"])
+                log.info("reservation found for namespace '%s' whcih no longer exists", ns)
     return False
 
 

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -296,8 +296,10 @@ def check_for_existing_reservation(requester):
     for res in get_all_reservations():
         res_state = res.get("status", {}).get("state")
         if res["spec"]["requester"] == requester and res_state == "active":
-            return True
-
+            if get_json("namespace", res["status"]["namespace"]):
+                return True
+            else:
+                log.info("a reservation was found for namespace '%s' which no longer exists", res["status"]["namespace"])
     return False
 
 


### PR DESCRIPTION
This corner case may occur:

1. Reserve NS with bonfire
2. Delete NS with some other tool like oc
3. Attempt to reserve again and bonfire tells you you have an active res

This patch amends the existing res check by verifying the ns exists. If it doesn't we log a message and let the user take out a new res.