### PR TITLE
Add a secondary tag for PR/MR image builds

### DIFF
--- a/cicd/README.md
+++ b/cicd/README.md
@@ -1,1 +1,48 @@
 Utilities used to run smoke tests in an ephemeral environment within a CI/CD pipeline
+
+
+See examples directory for a pr_check template, and some unit test templates. 
+# Scripts
+
+## bootstrap.sh
+
+Clone bonfire into workspace, setup python venv, modify PATH, login to container registries, login to Kube/OCP, and set envvars used by following scripts.
+
+## build.sh
+
+Using docker (rhel7) or podman (else) build, tag, and push an image to Quay and Red Hat registries.
+
+If its a GitHub or GitLab PR/MR triggered script execution, tag image with `pr-123-SHA` and `pr-123-testing`, else use a short SHA for the target repo HEAD.
+
+## deploy_ephemeral_db.sh
+
+Deploy using `bonfire process` and `<oc_wrapper> apply`, removing dependencies and setting up database envvars.
+
+## deploy_ephemeral_env.sh
+
+Deploy using `bonfire deploy` into ephemeral, specifying app, component, and relevant image tag args.  Passes `EXTRA_DEPLOY_ARGS` which can be set by the caller via pr_checks.sh.
+
+## cji_smoke_test.sh
+
+Run iqe-tests container for the relevant app plugin using `bonfire deploy-iqe-cji`. Waits for tests to complete, and fetches artifacts using minio.
+
+## post_test_results.sh
+
+Using artifacts fetched from `cji_smoke_test.sh`, add a GitHub status or GitLab comment linking to the relevant test results in Ibutsu.
+
+## smoke_test.sh
+
+DEPRECATED, use `cji_smoke_test.sh`
+
+## iqe_pod
+
+DEPRECATED, use `cji_smoke_test.sh`
+
+
+# Contributing
+
+Suggested method for testing changes to these scripts:
+- Modify `bootstrap.sh` to `git clone` your fork and branch of bonfire.
+- Open a PR in a repo using bonfire pr_checks and the relevant scripts, modifying `pr_check` script to clone your fork and branch of bonfire.
+- Observe modified scripts running in the relevant CI/CD pipeline.
+# 

--- a/cicd/bootstrap.sh
+++ b/cicd/bootstrap.sh
@@ -68,9 +68,7 @@ pip install --upgrade 'crc-bonfire>=4.4.0'
 
 # clone repo to download cicd scripts
 rm -fr $BONFIRE_ROOT
-# DONOTMERGE testing in pr_check against 
-# https://github.com/content-services/content-sources-backend/pull/82/files
-git clone --branch add-pr-latest-tag https://github.com/mshriver/bonfire.git $BONFIRE_ROOT
+git clone --branch master https://github.com/RedHatInsights/bonfire.git $BONFIRE_ROOT
 
 # Do a docker login to ensure our later 'docker pull' calls have an auth file created
 source ${CICD_ROOT}/_common_container_logic.sh

--- a/cicd/bootstrap.sh
+++ b/cicd/bootstrap.sh
@@ -68,7 +68,9 @@ pip install --upgrade 'crc-bonfire>=4.4.0'
 
 # clone repo to download cicd scripts
 rm -fr $BONFIRE_ROOT
-git clone --branch master https://github.com/RedHatInsights/bonfire.git $BONFIRE_ROOT
+# DONOTMERGE testing in pr_check against 
+# https://github.com/content-services/content-sources-backend/pull/82/files
+git clone --branch add-pr-latest-tag https://github.com/mshriver/bonfire.git $BONFIRE_ROOT
 
 # Do a docker login to ensure our later 'docker pull' calls have an auth file created
 source ${CICD_ROOT}/_common_container_logic.sh

--- a/cicd/build.sh
+++ b/cicd/build.sh
@@ -62,7 +62,7 @@ function docker_build {
 
     docker push "${IMAGE}:${IMAGE_TAG}"
     if  [ ! -z "$IMAGE_TAG_LATEST" ]; then
-        podman push "${IMAGE}:${IMAGE_TAG_LATEST}"
+        docker push "${IMAGE}:${IMAGE_TAG_LATEST}"
     fi
     set +x
 }


### PR DESCRIPTION
Within build.sh, construct `IMAGE_TAG_OPTS`
- In the case of a PR, use `pr-123-SHA` and `pr-123-latest` tags
- Docker push with --all-tags
- podman push twice

https://issues.redhat.com/browse/RHCLOUD-20838


Tested alongside this repo:
https://github.com/content-services/content-sources-backend/pull/82/files

Pipeline run:
https://ci.int.devshift.net/job/content-services-content-sources-backend-pr-check/82/console 

Resulting images:
![image](https://user-images.githubusercontent.com/21315076/186018426-96c58561-c630-419c-8747-36a606a38d26.png)


