### PR TITLE
Switch use 'operator-ns' label with 'pool'

### DIFF
--- a/tests/data/namespace_data.json
+++ b/tests/data/namespace_data.json
@@ -9,7 +9,6 @@
                     "reserved": "true"
                 },
                 "labels": {
-                    "operator-ns": "true",
                     "pool": "minimal"
                 }
             },
@@ -26,7 +25,6 @@
                     "reserved": "true"
                 },
                 "labels": {
-                    "operator-ns": "true",
                     "pool": "default"
                 }
             },
@@ -43,7 +41,6 @@
                     "reserved": "false,"
                 },
                 "labels": {
-                    "operator-ns": "true",
                     "pool": "default"
                 }
             },
@@ -60,7 +57,6 @@
                     "reserved": "false,"
                 },
                 "labels": {
-                    "operator-ns": "true",
                     "pool": "default"
                 }
             },
@@ -77,7 +73,6 @@
                     "reserved": "true"
                 },
                 "labels": {
-                    "operator-ns": "true",
                     "pool": "default"
                 }
             },


### PR DESCRIPTION
We used to identify namespaces owned by the ephemeral-namespace-operator by checking for the label `operator-ns`. Now that we have the `pool` label, we can also check all namespaces owned by the ENO by ensuring that these namespaces contain the `pool` label. This MR just removes the use of `operator-ns` and replaces it with `pool`. 