### PR TITLE
Adding UI changes for namespace limiting

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -679,15 +679,15 @@ def _cmd_namespace_reserve(name, requester, duration, pool, timeout, local):
 
         if get_namespace_quantity(pool):
             log.info(f"""Namespace max reached for '{pool}' pool
-            
+
                 Max number of namespaces for '{pool}' pool have been reserved. We apologize for
-                the inconvenience. 
-                
-                If you have any questions contact the DevProd team at the slack 
+                the inconvenience.
+
+                If you have any questions contact the DevProd team at the slack
                 channel #team-consoledot-devprod.
             """)
             exit()
-    
+
     log.info("Attempting to reserve a namespace...")
     if not has_ns_operator():
         _error(NO_RESERVATION_SYS)

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -683,8 +683,7 @@ def _cmd_namespace_reserve(name, requester, duration, pool, timeout, local):
                 Max number of namespaces for '{pool}' pool have been reserved. We apologize for
                 the inconvenience.
 
-                If you have any questions contact the DevProd team at the slack
-                channel #team-consoledot-devprod.
+                If you have any questions contact the DevProd team on Slack for more details.
             """)
             exit()
 

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -329,6 +329,7 @@ def get_reservation(name=None, namespace=None, requester=None):
 
     return None
 
+
 def get_pool_size_limit(pool):
     try:
         output = oc(["get", "NamespacePool", pool], o="json", _silent=True)
@@ -349,10 +350,12 @@ def get_pool_size_limit(pool):
 
     return pool_size
 
+
 def get_namespace_quantity(pool):
     """Get quantity of namespaces from the specified pool"""
     try:
-        namespace_count = len(oc(["get", "Namespaces", "-l", f'pool={pool}'], o="json", _silent=True))
+        command = ["get", "Namespaces", "-l", f'pool={pool}']
+        namespace_count = len(oc(command, o="json", _silent=True))
     except ErrorReturnCode as err:
         if "NotFound" in err.stderr:
             return f'Could not retrieve number of namespaces in "{pool}" pool'


### PR DESCRIPTION
This card adds UI enhancements that are directly related to adding limiting to namespace pools when `SizeLimit` is specified. This way users will know why they aren't able to reserve a namespace if the pool size limit has been reached. 

Here is an example of the output when this occurs:
```
2022-10-07 14:13:25 [    INFO] [          MainThread] Checking for available namespaces to reserve.
2022-10-07 14:13:25 [    INFO] [          MainThread] Pool size limit is defined as 3 in minimal pool
2022-10-07 14:13:25 [    INFO] [          MainThread] Namespace max reached for minimal pool
            
                Max number of namespaces for 'minimal' pool have been reserved. We apologize for
                the inconvenience. 
                
                If you have any questions contact the DevProd team at the slack 
                channel #hidden.
```