### PR TITLE
Adding UI changes for namespace limiting

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -682,10 +682,12 @@ def _cmd_namespace_reserve(name, requester, duration, pool, timeout, local, forc
     log.info("Checking for available namespaces to reserve.")
 
     if pool_size_limit := get_pool_size_limit(pool):
+        print(pool_size_limit)
+        print(get_reserved_namespace_quantity(pool))
         log.info(f"Pool size limit is defined as {pool_size_limit} in '{pool}' pool")
         if pool_size_limit > 0 and get_reserved_namespace_quantity(pool) >= pool_size_limit:
             _error(f"maximum number of namespaces for pool `{pool}` (limit: {pool_size_limit})"
-                   "have been reserved")
+                   " have been reserved")
 
     log.info("Attempting to reserve a namespace...")
     if not has_ns_operator():

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -684,14 +684,8 @@ def _cmd_namespace_reserve(name, requester, duration, pool, timeout, local, forc
         log.info(f"Pool size limit is defined as {pool_size_limit} in '{pool}' pool")
 
         if get_reserved_namespace_quantity(pool) == get_pool_size_limit(pool):
-            log.info(f"""Namespace max reached for '{pool}' pool
-
-                Max number of namespaces for '{pool}' pool have been reserved. We apologize for
-                the inconvenience.
-
-                If you have any questions contact the DevProd team on Slack for more details.
-            """)
-            exit()
+            _error(f"maximum number of namespaces for pool `{pool}` (limit: {size_limit})
+                     have been reserved")
 
     log.info("Attempting to reserve a namespace...")
     if not has_ns_operator():

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -34,7 +34,7 @@ from bonfire.openshift import (
     whoami,
     get_console_url,
     get_pool_size_limit,
-    get_namespace_quantity,
+    get_reserved_namespace_quantity,
 )
 from bonfire.processor import TemplateProcessor, process_clowd_env, process_iqe_cji
 from bonfire.qontract import get_apps_for_env, sub_refs
@@ -683,7 +683,9 @@ def _cmd_namespace_reserve(name, requester, duration, pool, timeout, local, forc
     if pool_size_limit := get_pool_size_limit(pool):
         log.info(f"Pool size limit is defined as {pool_size_limit} in '{pool}' pool")
 
-        if get_namespace_quantity(pool):
+        print(get_reserved_namespace_quantity(pool))
+        print(get_pool_size_limit(pool))
+        if get_reserved_namespace_quantity(pool) == get_pool_size_limit(pool):
             log.info(f"""Namespace max reached for '{pool}' pool
 
                 Max number of namespaces for '{pool}' pool have been reserved. We apologize for

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -53,7 +53,6 @@ log = logging.getLogger(__name__)
 APP_SRE_SRC = "appsre"
 LOCAL_SRC = "local"
 NO_RESERVATION_SYS = "this cluster does not use a namespace reservation system"
-NAMESPACES_UNAVAILABLE = "The pool specified has currently hit its limit for namespace reservations"
 
 _local_option = click.option(
     "--local",

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -683,8 +683,6 @@ def _cmd_namespace_reserve(name, requester, duration, pool, timeout, local, forc
     if pool_size_limit := get_pool_size_limit(pool):
         log.info(f"Pool size limit is defined as {pool_size_limit} in '{pool}' pool")
 
-        print(get_reserved_namespace_quantity(pool))
-        print(get_pool_size_limit(pool))
         if get_reserved_namespace_quantity(pool) == get_pool_size_limit(pool):
             log.info(f"""Namespace max reached for '{pool}' pool
 

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -688,7 +688,7 @@ def _cmd_namespace_reserve(name, requester, duration, pool, timeout, local, forc
 
         if reserved_namespace_count == pool_size_limit:
             _error(f"maximum number of namespaces for pool `{pool}` (limit: {pool_size_limit})"
-                  + "have been reserved")
+                    "have been reserved")
 
     log.info("Attempting to reserve a namespace...")
     if not has_ns_operator():

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -683,8 +683,7 @@ def _cmd_namespace_reserve(name, requester, duration, pool, timeout, local, forc
 
     if pool_size_limit := get_pool_size_limit(pool):
         log.info(f"Pool size limit is defined as {pool_size_limit} in '{pool}' pool")
-
-        if get_reserved_namespace_quantity(pool) == pool_size_limit:
+        if pool_size_limit > 0 and get_reserved_namespace_quantity(pool) >= pool_size_limit:
             _error(f"maximum number of namespaces for pool `{pool}` (limit: {pool_size_limit})"
                    "have been reserved")
 

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -689,8 +689,7 @@ def _cmd_namespace_reserve(name, requester, duration, pool, timeout, local, forc
                 Max number of namespaces for '{pool}' pool have been reserved. We apologize for
                 the inconvenience.
 
-                If you have any questions contact the DevProd team at the slack
-                channel #team-consoledot-devprod.
+                If you have any questions contact the DevProd team on Slack for more details.
             """)
             exit()
 

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -680,11 +680,14 @@ def _list_namespaces(available, mine, output):
 def _cmd_namespace_reserve(name, requester, duration, pool, timeout, local, force):
     """Reserve an ephemeral namespace"""
     log.info("Checking for available namespaces to reserve.")
+    pool_size_limit = get_pool_size_limit(pool)
+    reserved_namespace_count = get_reserved_namespace_quantity(pool)
+
     if pool_size_limit := get_pool_size_limit(pool):
         log.info(f"Pool size limit is defined as {pool_size_limit} in '{pool}' pool")
 
-        if get_reserved_namespace_quantity(pool) == get_pool_size_limit(pool):
-            _error(f"maximum number of namespaces for pool `{pool}` (limit: {size_limit})"
+        if reserved_namespace_count == pool_size_limit:
+            _error(f"maximum number of namespaces for pool `{pool}` (limit: {pool_size_limit})"
                   + "have been reserved")
 
     log.info("Attempting to reserve a namespace...")

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -680,13 +680,11 @@ def _list_namespaces(available, mine, output):
 def _cmd_namespace_reserve(name, requester, duration, pool, timeout, local, force):
     """Reserve an ephemeral namespace"""
     log.info("Checking for available namespaces to reserve.")
-    pool_size_limit = get_pool_size_limit(pool)
-    reserved_namespace_count = get_reserved_namespace_quantity(pool)
 
     if pool_size_limit := get_pool_size_limit(pool):
         log.info(f"Pool size limit is defined as {pool_size_limit} in '{pool}' pool")
 
-        if reserved_namespace_count == pool_size_limit:
+        if get_reserved_namespace_quantity(pool) == pool_size_limit:
             _error(f"maximum number of namespaces for pool `{pool}` (limit: {pool_size_limit})"
                    "have been reserved")
 

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -684,8 +684,8 @@ def _cmd_namespace_reserve(name, requester, duration, pool, timeout, local, forc
         log.info(f"Pool size limit is defined as {pool_size_limit} in '{pool}' pool")
 
         if get_reserved_namespace_quantity(pool) == get_pool_size_limit(pool):
-            _error(f"maximum number of namespaces for pool `{pool}` (limit: {size_limit})
-                     have been reserved")
+            _error(f"maximum number of namespaces for pool `{pool}` (limit: {size_limit})"
+                  + "have been reserved")
 
     log.info("Attempting to reserve a namespace...")
     if not has_ns_operator():

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -33,6 +33,8 @@ from bonfire.openshift import (
     wait_on_cji,
     whoami,
     get_console_url,
+    get_pool_size_limit,
+    get_namespace_quantity,
 )
 from bonfire.processor import TemplateProcessor, process_clowd_env, process_iqe_cji
 from bonfire.qontract import get_apps_for_env, sub_refs
@@ -51,6 +53,7 @@ log = logging.getLogger(__name__)
 APP_SRE_SRC = "appsre"
 LOCAL_SRC = "local"
 NO_RESERVATION_SYS = "this cluster does not use a namespace reservation system"
+NAMESPACES_UNAVAILABLE = "The pool specified has currently hit its limit for namespace reservations"
 
 _local_option = click.option(
     "--local",
@@ -676,6 +679,21 @@ def _list_namespaces(available, mine, output):
 @click_exception_wrapper("namespace reserve")
 def _cmd_namespace_reserve(name, requester, duration, pool, timeout, local, force):
     """Reserve an ephemeral namespace"""
+    log.info("Checking for available namespaces to reserve.")
+    if pool_size_limit := get_pool_size_limit(pool):
+        log.info(f"Pool size limit is defined as {pool_size_limit} in '{pool}' pool")
+
+        if get_namespace_quantity(pool):
+            log.info(f"""Namespace max reached for '{pool}' pool
+            
+                Max number of namespaces for '{pool}' pool have been reserved. We apologize for
+                the inconvenience. 
+                
+                If you have any questions contact the DevProd team at the slack 
+                channel #team-consoledot-devprod.
+            """)
+            exit()
+    
     log.info("Attempting to reserve a namespace...")
     if not has_ns_operator():
         _error(NO_RESERVATION_SYS)

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -682,8 +682,6 @@ def _cmd_namespace_reserve(name, requester, duration, pool, timeout, local, forc
     log.info("Checking for available namespaces to reserve.")
 
     if pool_size_limit := get_pool_size_limit(pool):
-        print(pool_size_limit)
-        print(get_reserved_namespace_quantity(pool))
         log.info(f"Pool size limit is defined as {pool_size_limit} in '{pool}' pool")
         if pool_size_limit > 0 and get_reserved_namespace_quantity(pool) >= pool_size_limit:
             _error(f"maximum number of namespaces for pool `{pool}` (limit: {pool_size_limit})"

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -688,7 +688,7 @@ def _cmd_namespace_reserve(name, requester, duration, pool, timeout, local, forc
 
         if reserved_namespace_count == pool_size_limit:
             _error(f"maximum number of namespaces for pool `{pool}` (limit: {pool_size_limit})"
-                    "have been reserved")
+                   "have been reserved")
 
     log.info("Attempting to reserve a namespace...")
     if not has_ns_operator():

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -222,7 +222,8 @@ _ns_reserve_options = [
         help="Specifies the pool type name",
     ),
     click.option(
-        "-f", "--force",
+        "-f",
+        "--force",
         is_flag=True,
         default=False,
         help="Don't prompt if reservations exist for user",

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -685,15 +685,15 @@ def _cmd_namespace_reserve(name, requester, duration, pool, timeout, local, forc
 
         if get_namespace_quantity(pool):
             log.info(f"""Namespace max reached for '{pool}' pool
-            
+
                 Max number of namespaces for '{pool}' pool have been reserved. We apologize for
-                the inconvenience. 
-                
-                If you have any questions contact the DevProd team at the slack 
+                the inconvenience.
+
+                If you have any questions contact the DevProd team at the slack
                 channel #team-consoledot-devprod.
             """)
             exit()
-    
+
     log.info("Attempting to reserve a namespace...")
     if not has_ns_operator():
         _error(NO_RESERVATION_SYS)

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -941,7 +941,7 @@ def _get_namespace(requested_ns_name, name, requester, duration, pool, timeout, 
             log.info("pool size limit is defined as %d in '%s' pool", pool_size_limit, pool)
             if pool_size_limit > 0 and get_reserved_namespace_quantity(pool) >= pool_size_limit:
                 _error(
-                    f"maximum number of namespaces for pool `{pool}` (limit: {pool_size_limit})"
+                    f"Maximum number of namespaces for pool `{pool}` (limit: {pool_size_limit})"
                     " have been reserved"
                 )
 

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -355,7 +355,7 @@ def get_reserved_namespace_quantity(pool):
     """Get quantity of namespaces from the specified pool"""
     try:
         command = ['get', 'namespace', '-l', f'pool={pool}', '-o',
-                'jsonpath="{.items[?(@.metadata.annotations.reserved=="true")].metadata.name}"']
+                   'jsonpath="{.items[?(@.metadata.annotations.reserved=="true")].metadata.name}"']
 
         namespaces = oc(command, _silent=True)
     except ErrorReturnCode as err:

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -354,9 +354,9 @@ def get_pool_size_limit(pool):
 def get_reserved_namespace_quantity(pool):
     """Get quantity of namespaces from the specified pool"""
     try:
-        command = ['get', 'namespace', '-l', f'pool={pool}', '-o', 
-            'jsonpath="{.items[?(@.metadata.annotations.reserved=="true")].metadata.name}"']
-            
+        command = ['get', 'namespace', '-l', f'pool={pool}', '-o',
+                'jsonpath="{.items[?(@.metadata.annotations.reserved=="true")].metadata.name}"']
+
         namespaces = oc(command, _silent=True)
     except ErrorReturnCode as err:
         if "NotFound" in err.stderr:

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -354,7 +354,9 @@ def get_pool_size_limit(pool):
 def get_reserved_namespace_quantity(pool):
     """Get quantity of namespaces from the specified pool"""
     try:
-        command = ['get', 'namespace', '-l', f'pool={pool}', '-o', 'jsonpath="{.items[?(@.metadata.annotations.reserved=="true")].metadata.name}"']
+        command = ['get', 'namespace', '-l', f'pool={pool}', '-o', 
+            'jsonpath="{.items[?(@.metadata.annotations.reserved=="true")].metadata.name}"']
+            
         namespaces = oc(command, _silent=True)
     except ErrorReturnCode as err:
         if "NotFound" in err.stderr:

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -1,7 +1,7 @@
 import functools
 import logging
 import time
-import json
+
 
 from ocviapy import (
     Resource,
@@ -332,22 +332,11 @@ def get_reservation(name=None, namespace=None, requester=None):
 
 def get_pool_size_limit(pool):
     pool_data = get_json("namespacepool", pool)
-    
+
     return int(pool_data["spec"].get("sizeLimit", 0)) if pool_data else 0
 
 
 def get_reserved_namespace_quantity(pool):
-    """Get quantity of namespaces from the specified pool"""
-    try:
-        command = ['get', 'namespace', '-l', f'pool={pool}', '-o',
-                   'jsonpath="{.items[?(@.metadata.annotations.reserved=="true")].metadata.name}"']
-
-        namespaces = oc(command, _silent=True)
-    except ErrorReturnCode as err:
-        if "NotFound" in err.stderr:
-            return f'Could not retrieve number of namespaces in "{pool}" pool'
-        raise
-
-    reservedNamespaceNames = "{}".format(namespaces).split()
-
-    return len(reservedNamespaceNames)
+    label = f"pool={pool}"
+    pool_namespaces = get_all_namespaces(label=label)
+    return len(pool_namespaces)

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -329,6 +329,7 @@ def get_reservation(name=None, namespace=None, requester=None):
 
     return None
 
+
 def get_pool_size_limit(pool):
     try:
         output = oc(["get", "NamespacePool", pool], o="json", _silent=True)
@@ -349,10 +350,12 @@ def get_pool_size_limit(pool):
 
     return pool_size
 
+
 def get_namespace_quantity(pool):
     """Get quantity of namespaces from the specified pool"""
     try:
-        namespace_count = len(oc(["get", "Namespaces", "-l", f'pool={pool}'], o="json", _silent=True))
+        command = ["get", "Namespaces", "-l", f'pool={pool}']
+        namespace_count = len(oc(command, o="json", _silent=True))
     except ErrorReturnCode as err:
         if "NotFound" in err.stderr:
             return f'Could not retrieve number of namespaces in "{pool}" pool'

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -12,7 +12,7 @@ from ocviapy import (
     oc,
     wait_for_ready_threaded,
     on_k8s,
-    get_all_namespaces
+    get_all_namespaces,
 )
 from sh import ErrorReturnCode
 from wait_for import TimedOutError, wait_for
@@ -339,7 +339,10 @@ def get_pool_size_limit(pool):
 def get_reserved_namespace_quantity(pool):
     label = f"pool={pool}"
     pool_namespaces = get_all_namespaces(label=label)
-    reserved_namespaces = [ns for ns in pool_namespaces
-                           if ns["metadata"].get("annotations", {}).get("reserved") == "true"]
+    reserved_namespaces = [
+        ns
+        for ns in pool_namespaces
+        if ns["metadata"].get("annotations", {}).get("reserved") == "true"
+    ]
 
     return len(reserved_namespaces)

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -332,8 +332,8 @@ def get_reservation(name=None, namespace=None, requester=None):
 
 def get_pool_size_limit(pool):
     pool_data = get_json("namespacepool", name=pool)
-
-    return int(pool_data["spec"].get("sizeLimit", 0)) if pool_data else 0
+    size_limit = pool_data["spec"].get("sizeLimit") if pool_data else 0
+    return int(size_limit) if size_limit else 0
 
 
 def get_reserved_namespace_quantity(pool):

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -332,12 +332,15 @@ def get_reservation(name=None, namespace=None, requester=None):
 
 
 def get_pool_size_limit(pool):
-    pool_data = get_json("namespacepool", pool)
+    pool_data = get_json("namespacepool", name=pool)
 
-    return int(pool_data["spec"].get("sizeLimit", 0)) if pool_data else 0
+    return int(pool_data["spec"].get("sizeLimit", None)) if pool_data else None
 
 
 def get_reserved_namespace_quantity(pool):
     label = f"pool={pool}"
     pool_namespaces = get_all_namespaces(label=label)
-    return len(pool_namespaces)
+    reserved_namespaces = [ns for ns in pool_namespaces 
+                           if ns["metadata"].get("annotations", {}).get("reserved") == "true"]
+   
+    return len(reserved_namespaces)

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -333,7 +333,7 @@ def get_reservation(name=None, namespace=None, requester=None):
 def get_pool_size_limit(pool):
     pool_data = get_json("namespacepool", name=pool)
 
-    return int(pool_data["spec"].get("sizeLimit", None)) if pool_data else None
+    return int(pool_data["spec"].get("sizeLimit", 0)) if pool_data else 0
 
 
 def get_reserved_namespace_quantity(pool):

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -354,14 +354,13 @@ def get_pool_size_limit(pool):
 def get_reserved_namespace_quantity(pool):
     """Get quantity of namespaces from the specified pool"""
     try:
-        command = ["get", "Namespaces", "-l", f'pool={pool}']
+        command = ['get', 'namespace', '-l', f'pool={pool}', '-o', 'jsonpath="{.items[?(@.metadata.annotations.reserved=="true")].metadata.name}"']
         namespaces = oc(command, _silent=True)
     except ErrorReturnCode as err:
         if "NotFound" in err.stderr:
             return f'Could not retrieve number of namespaces in "{pool}" pool'
         raise
-    
-    for namespace_count, line in enumerate(namespaces):
-        pass
 
-    return namespace_count
+    reservedNamespaceNames = "{}".format(namespaces).split()
+
+    return len(reservedNamespaceNames)

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -339,7 +339,7 @@ def get_pool_size_limit(pool):
 def get_reserved_namespace_quantity(pool):
     label = f"pool={pool}"
     pool_namespaces = get_all_namespaces(label=label)
-    reserved_namespaces = [ns for ns in pool_namespaces 
+    reserved_namespaces = [ns for ns in pool_namespaces
                            if ns["metadata"].get("annotations", {}).get("reserved") == "true"]
-   
+
     return len(reserved_namespaces)

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -13,6 +13,7 @@ from ocviapy import (
     oc,
     wait_for_ready_threaded,
     on_k8s,
+    get_all_namespaces
 )
 from sh import ErrorReturnCode
 from wait_for import TimedOutError, wait_for

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -2,7 +2,6 @@ import functools
 import logging
 import time
 
-
 from ocviapy import (
     Resource,
     ResourceWaiter,

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -331,24 +331,9 @@ def get_reservation(name=None, namespace=None, requester=None):
 
 
 def get_pool_size_limit(pool):
-    try:
-        output = oc(["get", "NamespacePool", pool], o="json", _silent=True)
-    except ErrorReturnCode as err:
-        if "NotFound" in err.stderr:
-            return {}
-        raise
-
-    try:
-        parsed_json = json.loads(str(output))
-    except ValueError:
-        return {}
-
-    try:
-        pool_size = parsed_json["spec"]["sizeLimit"]
-    except KeyError:
-        return None
-
-    return pool_size
+    pool_data = get_json("namespacepool", pool)
+    
+    return int(pool_data["spec"].get("sizeLimit", 0)) if pool_data else 0
 
 
 def get_reserved_namespace_quantity(pool):

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -351,14 +351,17 @@ def get_pool_size_limit(pool):
     return pool_size
 
 
-def get_namespace_quantity(pool):
+def get_reserved_namespace_quantity(pool):
     """Get quantity of namespaces from the specified pool"""
     try:
         command = ["get", "Namespaces", "-l", f'pool={pool}']
-        namespace_count = len(oc(command, o="json", _silent=True))
+        namespaces = oc(command, _silent=True)
     except ErrorReturnCode as err:
         if "NotFound" in err.stderr:
             return f'Could not retrieve number of namespaces in "{pool}" pool'
         raise
+    
+    for namespace_count, line in enumerate(namespaces):
+        pass
 
     return namespace_count

--- a/tests/test_bonfire.py
+++ b/tests/test_bonfire.py
@@ -34,6 +34,7 @@ def reservation_list():
 def test_ns_reserve_flag_name(mocker, caplog, name: str):
     caplog.set_level(100000)
 
+    mocker.patch("bonfire.bonfire.get_pool_size_limit", return_value=None)
     mocker.patch("bonfire.bonfire.has_ns_operator", return_value=True)
     mocker.patch("bonfire.bonfire._get_requester", return_value="user-3")
     mocker.patch("bonfire.bonfire.check_for_existing_reservation", return_value=False)
@@ -58,6 +59,7 @@ def test_ns_reserve_flag_name(mocker, caplog, name: str):
 def test_ns_reserve_flag_requester(mocker, caplog, requester: str):
     caplog.set_level(100000)
 
+    mocker.patch("bonfire.bonfire.get_pool_size_limit", return_value=None)
     mocker.patch("bonfire.bonfire.has_ns_operator", return_value=True)
     mocker.patch("bonfire.bonfire._get_requester", return_value=requester)
     mocker.patch("bonfire.bonfire.check_for_existing_reservation", return_value=False)
@@ -83,6 +85,7 @@ def test_ns_reserve_flag_requester(mocker, caplog, requester: str):
 def test_ns_reserve_flag_duration(mocker, caplog, duration: str):
     caplog.set_level(100000)
 
+    mocker.patch("bonfire.bonfire.get_pool_size_limit", return_value=None)
     mocker.patch("bonfire.bonfire.has_ns_operator", return_value=True)
     mocker.patch("bonfire.bonfire._get_requester", return_value="user-3")
     mocker.patch("bonfire.bonfire.check_for_existing_reservation", return_value=False)
@@ -242,6 +245,7 @@ def test_ns_list_flag_output(
 def test_ns_reserve_flag_timeout(mocker, caplog, user: str, namespace: str, timeout: int):
     caplog.set_level(100000)
 
+    mocker.patch("bonfire.bonfire.get_pool_size_limit", return_value=None)
     mocker.patch("bonfire.bonfire.has_ns_operator", return_value=True)
     mocker.patch("bonfire.namespaces.whoami", return_value=user)
     mocker.patch("bonfire.bonfire.check_for_existing_reservation", return_value=False)

--- a/tests/test_bonfire.py
+++ b/tests/test_bonfire.py
@@ -34,7 +34,7 @@ def reservation_list():
 def test_ns_reserve_flag_name(mocker, caplog, name: str):
     caplog.set_level(100000)
 
-    mocker.patch("bonfire.bonfire.get_pool_size_limit", return_value=None)
+    mocker.patch("bonfire.bonfire.get_pool_size_limit", return_value=0)
     mocker.patch("bonfire.bonfire.has_ns_operator", return_value=True)
     mocker.patch("bonfire.bonfire._get_requester", return_value="user-3")
     mocker.patch("bonfire.bonfire.check_for_existing_reservation", return_value=False)
@@ -44,7 +44,8 @@ def test_ns_reserve_flag_name(mocker, caplog, name: str):
     mock_process_reservation = mocker.patch("bonfire.namespaces.process_reservation")
 
     runner = CliRunner()
-    runner.invoke(bonfire.namespace, ["reserve", "--name", name])
+    result = runner.invoke(bonfire.namespace, ["reserve", "--name", name])
+    print(result.output)
 
     mock_process_reservation.assert_called_once_with(name, "user-3", "1h", "default", local=True)
 
@@ -59,7 +60,7 @@ def test_ns_reserve_flag_name(mocker, caplog, name: str):
 def test_ns_reserve_flag_requester(mocker, caplog, requester: str):
     caplog.set_level(100000)
 
-    mocker.patch("bonfire.bonfire.get_pool_size_limit", return_value=None)
+    mocker.patch("bonfire.bonfire.get_pool_size_limit", return_value=0)
     mocker.patch("bonfire.bonfire.has_ns_operator", return_value=True)
     mocker.patch("bonfire.bonfire._get_requester", return_value=requester)
     mocker.patch("bonfire.bonfire.check_for_existing_reservation", return_value=False)
@@ -69,7 +70,8 @@ def test_ns_reserve_flag_requester(mocker, caplog, requester: str):
     mock_process_reservation = mocker.patch("bonfire.namespaces.process_reservation")
 
     runner = CliRunner()
-    runner.invoke(bonfire.namespace, ["reserve", "--requester", requester])
+    result = runner.invoke(bonfire.namespace, ["reserve", "--requester", requester])
+    print(result.output)
 
     mock_process_reservation.assert_called_once_with(None, requester, "1h", "default", local=True)
 
@@ -85,7 +87,7 @@ def test_ns_reserve_flag_requester(mocker, caplog, requester: str):
 def test_ns_reserve_flag_duration(mocker, caplog, duration: str):
     caplog.set_level(100000)
 
-    mocker.patch("bonfire.bonfire.get_pool_size_limit", return_value=None)
+    mocker.patch("bonfire.bonfire.get_pool_size_limit", return_value=0)
     mocker.patch("bonfire.bonfire.has_ns_operator", return_value=True)
     mocker.patch("bonfire.bonfire._get_requester", return_value="user-3")
     mocker.patch("bonfire.bonfire.check_for_existing_reservation", return_value=False)
@@ -95,7 +97,8 @@ def test_ns_reserve_flag_duration(mocker, caplog, duration: str):
     mock_process_reservation = mocker.patch("bonfire.namespaces.process_reservation")
 
     runner = CliRunner()
-    runner.invoke(bonfire.namespace, ["reserve", "--duration", duration])
+    result = runner.invoke(bonfire.namespace, ["reserve", "--duration", duration])
+    print(result.output)
 
     if duration:
         mock_process_reservation.assert_called_once_with(
@@ -120,6 +123,7 @@ def test_ns_list_option(mocker, caplog, namespace_list: list, reservation_list: 
 
     runner = CliRunner()
     result = runner.invoke(bonfire.namespace, ["list"])
+    print(result.output)
 
     actual = " ".join(result.output.split())
 
@@ -166,6 +170,7 @@ def test_ns_list_option_mine(mocker, caplog, namespace_list: list, reservation_l
 
     runner = CliRunner()
     result = runner.invoke(bonfire.namespace, ["list", "--mine"])
+    print(result.output)
 
     actual = " ".join(result.output.split())
 
@@ -194,6 +199,7 @@ def test_ns_list_flag_output(
 
     runner = CliRunner()
     result = runner.invoke(bonfire.namespace, ["list", "--output", "json"])
+    print(result.output)
 
     actual_ns_1 = json.loads(result.output).get("ns-1")
     actual_ns_2 = json.loads(result.output).get("ns-2")
@@ -245,7 +251,7 @@ def test_ns_list_flag_output(
 def test_ns_reserve_flag_timeout(mocker, caplog, user: str, namespace: str, timeout: int):
     caplog.set_level(100000)
 
-    mocker.patch("bonfire.bonfire.get_pool_size_limit", return_value=None)
+    mocker.patch("bonfire.bonfire.get_pool_size_limit", return_value=0)
     mocker.patch("bonfire.bonfire.has_ns_operator", return_value=True)
     mocker.patch("bonfire.namespaces.whoami", return_value=user)
     mocker.patch("bonfire.bonfire.check_for_existing_reservation", return_value=False)
@@ -256,7 +262,8 @@ def test_ns_reserve_flag_timeout(mocker, caplog, user: str, namespace: str, time
     mock_wait_on_res = mocker.patch("bonfire.namespaces.wait_on_reservation")
 
     runner = CliRunner()
-    runner.invoke(bonfire.namespace, ["reserve", "--timeout", timeout])
+    result = runner.invoke(bonfire.namespace, ["reserve", "--timeout", timeout])
+    print(result.output)
 
     mock_wait_on_res.assert_called_once_with(ANY, timeout)
 
@@ -266,6 +273,7 @@ def test_pool_list_command(caplog):
 
     runner = CliRunner()
     result = runner.invoke(bonfire.pool, ["list"])
+    print(result.output)
 
     output = [r for r in result.output.split("\n") if r != ""]
 
@@ -284,6 +292,7 @@ def test_describe_ephemeral_ns(mocker):
     mocker.patch("bonfire.namespaces.Namespace")
     runner = CliRunner()
     result = runner.invoke(bonfire.namespace, ["describe", "ephemeral-blah"])
+    print(result.output)
 
     assert "jdoe | password" in result.output
     assert "env-ephemeral-blah-howdy" in result.output
@@ -297,6 +306,7 @@ def test_describe_empty_ns(mocker):
     mocker.patch("bonfire.namespaces.get_json")
     runner = CliRunner()
     result = runner.invoke(bonfire.namespace, ["describe"])
+    print(result.output)
 
     assert "Error: Missing argument 'NAMESPACE'." in result.output
     assert "env-ephemeral-blah-howdy" not in result.output
@@ -310,7 +320,8 @@ def test_describe_default_ns(mocker):
     mocker.patch("bonfire.namespaces.get_json")
     runner = CliRunner()
     try:
-        runner.invoke(bonfire.namespace, ["describe", "default"])
+        result = runner.invoke(bonfire.namespace, ["describe", "default"])
+        print(result.output)
     except FatalError:
         assert True
 
@@ -319,6 +330,7 @@ def test_describe_wrong_ns(mocker):
     mocker.patch("bonfire.namespaces.get_json", return_value=None)
     runner = CliRunner()
     try:
-        runner.invoke(bonfire.namespace, ["describe", "ephemeral-memes"])
+        result = runner.invoke(bonfire.namespace, ["describe", "ephemeral-memes"])
+        print(result.output)
     except FatalError:
         assert True


### PR DESCRIPTION
This card adds UI enhancements that are directly related to adding limiting to namespace pools when `SizeLimit` is specified. This way users will know why they aren't able to reserve a namespace if the pool size limit has been reached. 

Here is an example of the output when this occurs:
```
2022-10-12 09:43:48 [    INFO] [          MainThread] Checking for available namespaces to reserve.
2022-10-12 09:43:49 [    INFO] [          MainThread] Pool size limit is defined as 3 in 'minimal' pool
ERROR: maximum number of namespaces for pool `minimal` (limit: 3) have been reserved

```