### PR TITLE
feat: Error out if using appSRE source and not on internal network

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -46,7 +46,6 @@ from bonfire.utils import (
     get_version,
     split_equals,
     validate_time_string,
-    check_connection,
 )
 
 log = logging.getLogger(__name__)
@@ -759,7 +758,6 @@ def _get_apps_config(source, target_env, ref_env, local_config_path):
 
     if source == APP_SRE_SRC:
         log.info("fetching apps config using source: %s, target env: %s", source, target_env)
-        check_connection()
         if not target_env:
             _error("target env must be supplied for source '{APP_SRE_SRC}'")
         apps_config = get_apps_for_env(target_env)

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -4,6 +4,7 @@ import json
 import logging
 import sys
 import warnings
+import socket
 from functools import wraps
 
 import click
@@ -46,6 +47,7 @@ from bonfire.utils import (
     get_version,
     split_equals,
     validate_time_string,
+    check_connection,
 )
 
 log = logging.getLogger(__name__)
@@ -758,6 +760,7 @@ def _get_apps_config(source, target_env, ref_env, local_config_path):
 
     if source == APP_SRE_SRC:
         log.info("fetching apps config using source: %s, target env: %s", source, target_env)
+        check_connection()
         if not target_env:
             _error("target env must be supplied for source '{APP_SRE_SRC}'")
         apps_config = get_apps_for_env(target_env)

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -4,7 +4,6 @@ import json
 import logging
 import sys
 import warnings
-import socket
 from functools import wraps
 
 import click

--- a/bonfire/qontract.py
+++ b/bonfire/qontract.py
@@ -10,6 +10,7 @@ from gql.transport.requests import RequestsHTTPTransport
 from requests.auth import HTTPBasicAuth
 
 import bonfire.config as conf
+from bonfire.utils import check_url_connection
 
 log = logging.getLogger(__name__)
 
@@ -94,6 +95,8 @@ class Client:
         elif conf.QONTRACT_USERNAME and conf.QONTRACT_PASSWORD:
             log.debug("using basic authentication")
             transport_kwargs["auth"] = HTTPBasicAuth(conf.QONTRACT_USERNAME, conf.QONTRACT_PASSWORD)
+
+        check_url_connection(transport_kwargs["url"])
 
         transport = RequestsHTTPTransport(**transport_kwargs)
         self.client = GQLClient(transport=transport, fetch_schema_from_transport=True)

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -547,4 +547,4 @@ def check_connection(hostname="gitlab.cee.redhat.com"):
     try:
         socket.gethostbyname(hostname)
     except socket.gaierror:
-        raise FatalError(f"Unable to connect to {hostname} Check VPN Connection.")
+        raise FatalError(f"Unable to connect to {hostname}. Check VPN Connection.")

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -1,4 +1,5 @@
 import atexit
+from functools import cache
 import json
 import logging
 import os
@@ -10,6 +11,7 @@ import time
 import socket
 from distutils.version import StrictVersion
 from pathlib import Path
+from urllib.parse import urlparse
 
 import pkg_resources
 import requests
@@ -20,6 +22,10 @@ from cached_property import cached_property
 class FatalError(Exception):
     """An exception that will cause the CLI to exit"""
 
+    pass
+
+
+class ConnectionError(FatalError):
     pass
 
 
@@ -260,9 +266,9 @@ class RepoFile:
 
     def _get_gl_commit_hash(self):
         group, project = self.org, self.repo
-        response = self._session.get(
-            GL_PROJECTS_URL.format(type="groups", group=group), verify=self._gl_certfile
-        )
+        url = GL_PROJECTS_URL.format(type="groups", group=group)
+        check_url_connection(url)
+        response = self._session.get(url, verify=self._gl_certfile)
         if response.status_code == 404:
             # Weird quirk in gitlab API. If it's a user instead of a group, need to
             # use a different path
@@ -295,6 +301,7 @@ class RepoFile:
             commit = self._get_gl_commit_hash()
 
         url = GL_RAW_URL.format(group=self.org, project=self.repo, ref=commit, path=self.path)
+        check_url_connection(url)
         response = self._session.get(url, verify=self._gl_certfile)
         if response.status_code == 404:
             log.warning(
@@ -308,12 +315,10 @@ class RepoFile:
 
     def _get_gh_commit_hash(self):
         def get_ref_func(ref):
+            url = GH_BRANCH_URL.format(org=self.org, repo=self.repo, branch=ref)
+            check_url_connection(url)
             return self._session.get(
-                GH_BRANCH_URL.format(
-                    org=self.org,
-                    repo=self.repo,
-                    branch=ref,
-                ),
+                url,
                 headers=self._gh_auth_headers,
             )
 
@@ -327,6 +332,7 @@ class RepoFile:
             commit = self._get_gh_commit_hash()
 
         url = GH_RAW_URL.format(org=self.org, repo=self.repo, ref=commit, path=self.path)
+        check_url_connection(url)
         response = self._session.get(url, headers=self._gh_auth_headers)
         if response.status_code == 404:
             log.warning(
@@ -540,11 +546,29 @@ def hms_to_seconds(s):
     return seconds
 
 
-def check_connection(hostname="gitlab.cee.redhat.com"):
+@cache
+def check_hostname(hostname):
     """
     Check connection makes sure a connection is available to a given hostname.
+
+    Function is cached so that we only check a hostname once.
     """
+    log.debug("checking connection to '%s'", hostname)
+
     try:
         socket.gethostbyname(hostname)
     except socket.gaierror:
-        raise FatalError(f"Unable to connect to {hostname}. Check VPN Connection.")
+        raise ConnectionError(
+            f"Unable to resolve hostname '{hostname}'. Check network connection (is VPN needed?)"
+        )
+
+
+def check_url_connection(url):
+    try:
+        parsed_url = urlparse(url)
+    except (ValueError) as err:
+        raise ValueError(f"invalid url '{url}': {err}")
+
+    hostname = parsed_url.netloc
+
+    return check_hostname(hostname)

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -7,6 +7,7 @@ import shlex
 import subprocess
 import tempfile
 import time
+import socket
 from distutils.version import StrictVersion
 from pathlib import Path
 
@@ -537,3 +538,13 @@ def hms_to_seconds(s):
                 seconds += int(group.split("s")[0])
 
     return seconds
+
+
+def check_connection(hostname="gitlab.cee.redhat.com"):
+    """
+    Check connection makes sure a connection is available to a given hostname.
+    """
+    try:
+        socket.gethostbyname(hostname)
+    except socket.gaierror:
+        raise FatalError(f"Unable to connect to {hostname} Check VPN Connection.")


### PR DESCRIPTION
Add a simple network connetion check to see if we can reach internal resources.
If we're using the appSRE source and can't get a DNS response for gitlab, we error out.

This is to keep bonfire from hanging when not connected to the VPN as listed in RHCLOUD-21617

---

Add a check_connection function to error out if we cant' reach required
sources when running bonfire. Without this we hang for a very long time.

This also adds a message to inform the user to check their VPN
connection.

RHCLOUD-21617

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>
