### PR TITLE
Run tests with python 3.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.6'
           architecture: 'x64'
 
       - name: Install


### PR DESCRIPTION
Since app-sre jenkins agents appear to run with py 3.6, we should run the PR tests with that version.