### PR TITLE
Do not prompt a user for input when not outputting to a tty

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -139,12 +139,15 @@ def _confirm_or_abort(msg):
     if conf.BONFIRE_BOT:
         # these types of warnings shouldn't occur in automated runs, error out immediately
         _error(msg)
-    elif not sys.stdout.isatty():
-        _error(msg + " Output is not a tty. Aborting.")
     else:
         # have end user confirm if they want to proceed anyway
-        msg = f"{msg}.  Continue anyway?"
-        if not click.confirm(msg):
+        click.echo(f"\n{msg}")
+        prompt = "Continue anyway?"
+        if not sys.stdout.isatty():
+            _error(
+                f"Prompt cannot be answered:\n\n{msg}\n{prompt}\n\nOutput is not a TTY. Aborting."
+            )
+        if not click.confirm(prompt):
             click.echo("Aborting")
             sys.exit(0)
 

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -139,6 +139,8 @@ def _confirm_or_abort(msg):
     if conf.BONFIRE_BOT:
         # these types of warnings shouldn't occur in automated runs, error out immediately
         _error(msg)
+    elif not sys.stdout.isatty():
+        _error(msg + " Output is not a tty. Aborting.")
     else:
         # have end user confirm if they want to proceed anyway
         msg = f"{msg}.  Continue anyway?"
@@ -162,7 +164,7 @@ def _warn_before_delete():
 def _warn_of_existing(requester):
     _confirm_or_abort(
         f"Existing reservation(s) found for requester '{requester}', "
-        "consider re-using the existing namespace"
+        "consider re-using the existing namespace."
     )
 
 

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -301,7 +301,7 @@ def check_for_existing_reservation(requester):
             if get_json("namespace", ns):
                 return True
             else:
-                log.info("reservation found for namespace '%s' whcih no longer exists", ns)
+                log.info("reservation found for namespace '%s' which no longer exists", ns)
     return False
 
 


### PR DESCRIPTION
If the user is piping their output somewhere other than stdout, then we shouldn't prompt them for input. 

I thought about moving the prompt and then switching back to the previous output, but I think it's better to go ahead and error out and let them re-run the command with `-f` or use the namespace they already have.

RHCLOUD-20009