### PR TITLE
Update to latest setuptools, refactor project config

### DIFF
--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -13,7 +13,7 @@ from distutils.version import StrictVersion
 from pathlib import Path
 from urllib.parse import urlparse
 
-import pkg_resources
+from importlib.metadata import version, PackageNotFoundError
 import requests
 import yaml
 from cached_property import cached_property
@@ -443,8 +443,8 @@ def load_file(path):
 
 def get_version():
     try:
-        return pkg_resources.get_distribution(PKG_NAME).version
-    except pkg_resources.DistributionNotFound:
+        return version(PKG_NAME)
+    except PackageNotFoundError:
         return "0.0.0"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools==60.10.0"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,0 @@
-from setuptools import setup
-
-setup(
-    use_scm_version=True,
-)


### PR DESCRIPTION
- Removes pin to specific setuptools version (**resources** dir seems to be fine, WRT comment in 005883122bed8c72b7e60cb4cc424b293eb9d05b)
- Removes `tests` from wheel to avoid them being distributed
- Refactor `setuptools_scm` and `setuptools` config sections to not to require setup.py
- Replace usage of `pkg_resources` with `importlib.metadata` for calculating `version`