### PR TITLE
Auto-add a larger list of components for frontends

### DIFF
--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -54,6 +54,8 @@ BONFIRE_NS_REQUESTER = os.getenv("BONFIRE_NS_REQUESTER")
 # set to true when bonfire is running via automation using a bot acct (not an end user)
 BONFIRE_BOT = os.getenv("BONFIRE_BOT")
 
+AUTO_ADDED_FRONTEND_DEPENDENCIES = ("frontend-configs", "rbac", "rbac-frontend", "host-inventory", "host-inventory-frontend")
+
 
 def write_default_config(outpath=None):
     outpath = Path(outpath) if outpath else DEFAULT_CONFIG_PATH

--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -54,7 +54,13 @@ BONFIRE_NS_REQUESTER = os.getenv("BONFIRE_NS_REQUESTER")
 # set to true when bonfire is running via automation using a bot acct (not an end user)
 BONFIRE_BOT = os.getenv("BONFIRE_BOT")
 
-AUTO_ADDED_FRONTEND_DEPENDENCIES = ("frontend-configs", "rbac", "rbac-frontend", "host-inventory", "host-inventory-frontend")
+AUTO_ADDED_FRONTEND_DEPENDENCIES = (
+    "frontend-configs",
+    "rbac",
+    "rbac-frontend",
+    "host-inventory",
+    "host-inventory-frontend",
+)
 
 
 def write_default_config(outpath=None):

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -586,13 +586,10 @@ class TemplateProcessor:
     def _handle_dependencies(self, app_name, processed_component, in_recursion):
         items = processed_component.items
         if self._frontend_found(items):
-            if "frontend-configs" not in self.processed_components:
-                log.info("found a Frontend resource, auto-adding frontend-configs as dependency")
-                self._process_component("frontend-configs", app_name, in_recursion)
-            if "rbac" not in self.processed_components:
-                log.info("found a Frontend resource, auto-adding rbac as dependency")
-                self._process_component("rbac", app_name, in_recursion)
-
+            for name in conf.AUTO_ADDED_FRONTEND_DEPENDENCIES:
+                if name not in self.processed_components:
+                    log.info("auto-adding %s as dependency for frontend resource", name)
+                    self._process_component(name, app_name, in_recursion)
         self._add_dependencies_to_config(app_name, processed_component, in_recursion)
 
     def _process_component(self, component_name, app_name, in_recursion):


### PR DESCRIPTION
Many apps require rbac and host-inventory frontends to be present in order for their Frontend to operate properly. As a quick fix, if `--frontends=true` is passed to bonfire, the components listed in `conf.AUTO_ADDED_FRONTEND_DEPENDENCIES` will be auto-deployed. This PR adds host-inventory backend, host-inventory frontend, and rbac frontend to the list of what was already being auto-deployed.