### PR TITLE
Gitlab CI tweaks: Add release back in, tweak pip installs during test run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Publish crc-bonfire to PyPI
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+
+jobs:
+  build-and-publish:
+    name: Build and publish to PyPI
+    if: startsWith(github.event.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout to master
+        uses: actions/checkout@v3
+
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          architecture: 'x64'
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install -U pip
+          pip install -U wheel setuptools build twine
+
+      - name: Build sdist and wheel
+        run: |
+          python -m build -o dist/
+      
+      - name: Twine check
+        run: python -m twine check dist/*
+
+      - name: Deploy to PyPi
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_token }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   build:
-    name: Build sdist and wheel
     runs-on: ubuntu-latest
     steps:
 
@@ -35,6 +34,20 @@ jobs:
       with:
         name: dist
         path: dist
+
+  build_check:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+        architecture: 'x64'
+    - uses: actions/download-artifact@v3
+      with:
+        name: dist
+        path: dist
+    - run: pipx run twine check --strict dist/*
 
   test:
     runs-on: ubuntu-latest
@@ -72,17 +85,3 @@ jobs:
         bonfire config write-default
     - name: pytest
       run: pytest -sv
-
-  build_check:
-    runs-on: ubuntu-latest
-    needs: [build]
-    steps:
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-        architecture: 'x64'
-    - uses: actions/download-artifact@v3
-      with:
-        name: dist
-        path: dist
-    - run: pipx run twine check --strict dist/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,19 +86,3 @@ jobs:
         name: dist
         path: dist
     - run: pipx run twine check --strict dist/*
-
-  dist_upload:
-    name: Publish Python 🐍 distributions to PyPI
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') }}
-    needs: [build_check, test]
-    steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: dist
-        path: dist
-    - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        user: __token__
-        password: ${{ secrets.pypi_token }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,6 @@ jobs:
       matrix:
         # todo: extract from source
         python-version: [ 3.6, 3.7, 3.8, 3.9, '3.10' ]
-        install-from: ["dist/*.whl"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -70,13 +69,15 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U setuptools setuptools_scm pytest
+        pip install -U setuptools wheel setuptools_scm
     - uses: actions/download-artifact@v3
       with:
         name: dist
         path: dist
-    - name: install ${{ matrix.install-from }}[test]
-      run: pip install ${{ matrix.install-from }}
+    - name: install wheel with test extras
+      run: |
+        WHEEL_FILE=$(ls dist/*.whl)
+        pip install "$WHEEL_FILE[test]"
     - name: test bonfire version and create default config file
       run: |
         pip list | grep crc-bonfire


### PR DESCRIPTION
Due to the `on` definition at the top of tests.yml, those steps only run for PRs. Therefore, the dist_upload step never gets executed. Re-adding the release file here so that tagging on the main branch results in a PyPI release.