### PR TITLE
Optional namespace

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -925,15 +925,7 @@ def _cmd_process(
 
 
 def _get_namespace(
-    requested_ns_name,
-    name,
-    requester,
-    duration,
-    pool,
-    timeout,
-    local,
-    force,
-    using_current=False
+    requested_ns_name, name, requester, duration, pool, timeout, local, force, using_current=False
 ):
 
     if not has_ns_operator():
@@ -950,8 +942,11 @@ def _get_namespace(
     reserved_new_ns = False
     if not ns:
         if using_current:
-            log.info("Current namespace '%s' could not be used (not reserved,"
-                     " expired, or not owned), reserving a new one", requested_ns_name)
+            log.info(
+                "Current namespace '%s' could not be used (not reserved,"
+                " expired, or not owned), reserving a new one",
+                requested_ns_name,
+            )
 
         ns = _check_and_reserve_namespace(name, requester, duration, pool, timeout, local, force)
         reserved_new_ns = True
@@ -963,9 +958,7 @@ def _check_and_use_namespace(requested_ns_name, using_current):
     if not has_ns_operator():
         _error(f"{NO_RESERVATION_SYS}")
 
-    log.debug(
-        "checking if namespace '%s' has been reserved via ns operator...", requested_ns_name
-    )
+    log.debug("checking if namespace '%s' has been reserved via ns operator...", requested_ns_name)
     operator_reservation = get_reservation(namespace=requested_ns_name)
     ns = None
     if operator_reservation:
@@ -1022,14 +1015,18 @@ def _check_and_reserve_namespace(name, requester, duration, pool, timeout, local
 @click.option(
     "--namespace",
     "-n",
-    help="Namespace (defaults to namespace from current context; "
-         "if not set, not reserved, or not owned, then bonfire will reserve a new one)",
+    help=(
+        "Namespace (defaults to namespace from current context; "
+        "if not set, not reserved, or not owned, then bonfire will reserve a new one)"
+    ),
     default=None,
 )
 @click.option(
     "--reserve",
-    help="Do not use current context's namespace and force reserve a new one. (keeps"
-         " the reservation on failure)",
+    help=(
+        "Do not use current context's namespace and force reserve a new one. (keeps"
+        " the reservation on failure)"
+    ),
     is_flag=True,
 )
 @click.option(
@@ -1095,8 +1092,15 @@ def _cmd_config_deploy(
         namespace = get_current_namespace()
 
     ns, reserved_new_ns = _get_namespace(
-        namespace, name, requester, duration, pool, timeout, local, force,
-        using_current=using_current
+        namespace,
+        name,
+        requester,
+        duration,
+        pool,
+        timeout,
+        local,
+        force,
+        using_current=using_current,
     )
 
     if import_secrets:

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -716,10 +716,10 @@ def _cmd_namespace_release(namespace, force, local):
         namespace = current_namespace_or_error()
 
     if not force:
-        _warn_before_delete()
         ns = Namespace(name=namespace)
         if not ns.owned_by_me:
             _warn_if_not_owned_by_me()
+        _warn_before_delete()
 
     release_reservation(namespace=namespace, local=local)
 

--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -3,7 +3,7 @@ import datetime
 import logging
 import base64
 
-from ocviapy import apply_config, get_all_namespaces, get_json, on_k8s
+from ocviapy import apply_config, get_all_namespaces, get_json, on_k8s, set_current_namespace
 from wait_for import TimedOutError
 
 import bonfire.config as conf
@@ -290,6 +290,10 @@ def reserve_namespace(name, requester, duration, pool, timeout, local=True):
         duration,
         pool,
     )
+
+    if not conf.BONFIRE_BOT:
+        # set reserved namespace as current
+        set_current_namespace(ns_name)
 
     url = get_console_url()
     if url:

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -20,6 +20,7 @@ from wait_for import TimedOutError, wait_for
 log = logging.getLogger(__name__)
 
 
+@functools.lru_cache(maxsize=None, typed=False)
 def has_ns_operator():
     for res in get_api_resources():
         name = res["name"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     wait-for
     tabulate
     python-dotenv
-    ocviapy>=1.2.1
+    ocviapy>=1.2.2
     app-common-python>=0.1.6
     junitparser
     importlib-metadata>=0.12;python_version<"3.8"

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     wait-for
     tabulate
     python-dotenv
-    ocviapy>=1.0.1
+    ocviapy>=1.2.0
     app-common-python>=0.1.6
     junitparser
     importlib-metadata>=0.12;python_version<"3.8"

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     wait-for
     tabulate
     python-dotenv
-    ocviapy>=1.2.0
+    ocviapy>=1.2.1
     app-common-python>=0.1.6
     junitparser
     importlib-metadata>=0.12;python_version<"3.8"

--- a/tests/test_bonfire.py
+++ b/tests/test_bonfire.py
@@ -299,18 +299,20 @@ def test_describe_ephemeral_ns(mocker):
     assert "yes.redhat.com" in result.output
 
 
-def test_describe_empty_ns(mocker):
+def test_describe_ephemeral_ns_from_ctx(mocker):
     mocker.patch("bonfire.namespaces.get_console_url", return_value="yes.redhat.com")
     mocker.patch("bonfire.namespaces.get_keycloak_creds", return_value=default_kc)
     mocker.patch("bonfire.namespaces.get_fe_hostname", return_value=eph_test_route)
     mocker.patch("bonfire.namespaces.get_json")
+    mocker.patch("bonfire.namespaces.Namespace")
+    mocker.patch("bonfire.bonfire.current_namespace_or_error", return_value='ephemeral-blah')
     runner = CliRunner()
     result = runner.invoke(bonfire.namespace, ["describe"])
     print(result.output)
 
-    assert "Error: Missing argument 'NAMESPACE'." in result.output
-    assert "env-ephemeral-blah-howdy" not in result.output
-    assert "yes.redhat.com" not in result.output
+    assert "jdoe | password" in result.output
+    assert "env-ephemeral-blah-howdy" in result.output
+    assert "yes.redhat.com" in result.output
 
 
 def test_describe_default_ns(mocker):


### PR DESCRIPTION
**Needs testing**

Use namespace from current context for majority of bonfire commands,
making the --namespace optional.

The deploy command tries to use current namespace, and if it is not
reserved or not owned it reserves a new one.  This is to keep backwards
compatiblity.

On each reservation a new namespace is set on current (or appropriate) context.

Adds --reserve option to deploy command to force a reservation of new
namespace.