### PR TITLE
Pin ubuntu to 20.04 to fix py3.6 tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   build-and-publish:
     name: Build and publish to PyPI
     if: startsWith(github.event.ref, 'refs/tags')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout to master
         uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
 
     - name: Checkout to master
@@ -36,7 +36,7 @@ jobs:
         path: dist
 
   build_check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [build]
     steps:
     - uses: actions/setup-python@v4
@@ -50,7 +50,7 @@ jobs:
     - run: pipx run twine check --strict dist/*
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [build]
     strategy:
       matrix:


### PR DESCRIPTION
As discussed in https://github.com/actions/setup-python/issues/544