### PR TITLE
Invoke pip with `python3 -m pip`

### DIFF
--- a/cicd/bootstrap.sh
+++ b/cicd/bootstrap.sh
@@ -43,6 +43,8 @@ export KUBECONFIG="$KUBECONFIG_DIR/config"
 rm -fr $KUBECONFIG_DIR
 mkdir $KUBECONFIG_DIR
 
+set +x
+
 # if this is a PR, use a different tag, since PR tags expire
 if [ ! -z "$ghprbPullId" ]; then
   export IMAGE_TAG="pr-${ghprbPullId}-${IMAGE_TAG}"
@@ -65,7 +67,6 @@ export LC_ALL=en_US.utf-8
 python3 -m venv .bonfire_venv
 source .bonfire_venv/bin/activate
 
-set +x
 python3 -m pip install --upgrade pip 'setuptools<58' wheel
 python3 -m pip install --upgrade 'crc-bonfire>=4.10.4'
 

--- a/cicd/bootstrap.sh
+++ b/cicd/bootstrap.sh
@@ -42,7 +42,6 @@ export KUBECONFIG_DIR="$WORKSPACE/.kube"
 export KUBECONFIG="$KUBECONFIG_DIR/config"
 rm -fr $KUBECONFIG_DIR
 mkdir $KUBECONFIG_DIR
-set +x
 
 # if this is a PR, use a different tag, since PR tags expire
 if [ ! -z "$ghprbPullId" ]; then
@@ -66,6 +65,7 @@ export LC_ALL=en_US.utf-8
 python3 -m venv .bonfire_venv
 source .bonfire_venv/bin/activate
 
+set +x
 pip install --upgrade pip 'setuptools<58' wheel
 pip install --upgrade 'crc-bonfire>=4.10.4'
 

--- a/cicd/bootstrap.sh
+++ b/cicd/bootstrap.sh
@@ -66,8 +66,8 @@ python3 -m venv .bonfire_venv
 source .bonfire_venv/bin/activate
 
 set +x
-pip install --upgrade pip 'setuptools<58' wheel
-pip install --upgrade 'crc-bonfire>=4.10.4'
+python3 -m pip install --upgrade pip 'setuptools<58' wheel
+python3 -m pip install --upgrade 'crc-bonfire>=4.10.4'
 
 # clone repo to download cicd scripts
 rm -fr $BONFIRE_ROOT


### PR DESCRIPTION
When invoking pip directly, I was seeing errors in the Jenkins job. When I switched to invoking with `python3 -m pip` I was able to get beyond my errors. It sounds like this is the recommended way to invoke pip now, so I'd advocate for adopting this in bootstrap.sh unless there are reasonable objections.