### PR TITLE
Restore adding expiry label to Dockerfile

### DIFF
--- a/cicd/build.sh
+++ b/cicd/build.sh
@@ -52,13 +52,7 @@ function build {
     fi
 }
 
-# Used to add a new line to the Dockerfile to add the
-# automatic expiry date for PR/MR-only images.
-#
-# Adding a new line to the Dockerfile adds a new layer,
-# preventing Podman to associate the expiry label to the
-# release image when running on master after merging the
-# MR/PR.
+# https://github.com/RedHatInsights/bonfire/issues/291
 add_expiry_label_to_file() {
 
     local FILE="$1"

--- a/cicd/build.sh
+++ b/cicd/build.sh
@@ -20,10 +20,6 @@ is_pr_or_mr_build() {
     [ -n "$ghprbPullId" ] || [ -n "$gitlabMergeRequestId" ]
 }
 
-get_expiry_label_parameter() {
-    echo "--label quay.expires-after=${QUAY_EXPIRE_TIME}"
-}
-
 is_rhel7_host() {
 
     local RELEASE_FILE='/etc/redhat-release'
@@ -34,14 +30,15 @@ is_rhel7_host() {
 function build {
 
     local IMAGE_TAG_LATEST=''
+    local DOCKERFILE_PATH="${APP_ROOT}/${DOCKERFILE}"
 
-    if [ ! -f "$APP_ROOT/$DOCKERFILE" ]; then
-        echo "ERROR: No $DOCKERFILE found"
+    if [ ! -f "$DOCKERFILE_PATH" ]; then
+        echo "ERROR: Dockerfile '$DOCKERFILE_PATH' not found"
         exit 1
     fi
 
     if is_pr_or_mr_build; then
-        CMD_OPTS+=" $(get_expiry_label_parameter)"
+        add_expiry_label_to_dockerfile "$DOCKERFILE_PATH" "$QUAY_EXPIRE_TIME"
         IMAGE_TAG_LATEST="$(cut -d "-" -f 1,2 <<< $IMAGE_TAG)-latest"
         CMD_OPTS+=" -t ${IMAGE}:${IMAGE_TAG_LATEST} --build-arg TEST_IMAGE=true"
     fi
@@ -53,6 +50,32 @@ function build {
         # on RHEL8 or anything else, use podman
         podman_build
     fi
+}
+
+# Used to add a new line to the Dockerfile to add the
+# automatic expiry date for PR/MR-only images.
+#
+# Adding a new line to the Dockerfile adds a new layer,
+# preventing Podman to associate the expiry label to the
+# release image when running on master after merging the
+# MR/PR.
+add_expiry_label_to_file() {
+
+    local FILE="$1"
+    local EXPIRE_TIME="$2"
+    local LABEL="quay.expires-after=${EXPIRE_TIME}"
+
+    local LINE="LABEL ${LABEL}"
+
+    if ! _file_ends_with_newline "$FILE"; then
+        LINE="\n${LINE}"
+    fi
+
+    echo -e "${LINE}" >> "$FILE"
+}
+
+_file_ends_with_newline() {
+    [ $(tail -1 "$1" | wc -l) -ne 0 ]
 }
 
 function docker_build {


### PR DESCRIPTION
This restores the behavior changed with #286 , as it brought up the issue describe in #291, as no new layers are added during PR/MR runs since the Dockerfile was not modified.

until #291 is sorted out, I'm adding back the "modify Dockerfile functionality" since it avoids `podman` to wrongly associate the expiry labels to release images.