### PR TITLE
Fix: Bonfire does not respect overriding IMAGE_TAG when dependencies …

### DIFF
--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -606,7 +606,19 @@ class TemplateProcessor:
         else:
             log.info("processing component %s", component_name)
             items = self._get_component_items(component_name)
-
+            for components in items:
+                try:
+                    n = components['metadata']['name']
+                    """
+                    Local yaml config parameters (like IMAGE_TAG) will be overwritten by their proper
+                    upstream components unless we rename our local component_name
+                    to the correct one again.
+                    """
+                    if n in component_name:
+                        component_name = n
+                        break
+                except KeyError:
+                    continue
             # ignore frontends if we're not supposed to deploy them
             if self._frontend_found(items) and not self.frontends:
                 log.info(

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -610,8 +610,8 @@ class TemplateProcessor:
                 try:
                     n = components['metadata']['name']
                     """
-                    Local yaml config parameters (like IMAGE_TAG) will be overwritten by their proper
-                    upstream components unless we rename our local component_name
+                    Local yaml config parameters (like IMAGE_TAG) will be overwritten by their
+                    proper upstream components unless we rename our local component_name
                     to the correct one again.
                     """
                     if n in component_name:


### PR DESCRIPTION
…are involved

When a local component is trying to be deployed against a specific IMAGE_TAG for example, it gets overridden by the real upstream clowdapp during deploy. This behavior is not shown in bonfire process $APP.

[RHCLOUD-25035](https://issues.redhat.com/browse/RHCLOUD-25035)