### PR TITLE
Handle deploy targets that have None namespace

### DIFF
--- a/bonfire/qontract.py
+++ b/bonfire/qontract.py
@@ -282,7 +282,7 @@ def get_apps_for_env(env_name):
         for saas_file in saas_files:
             for resource_template in saas_file.get("resourceTemplates", []):
                 for target in resource_template.get("targets", []):
-                    if target["namespace"]["name"] in env["namespaces"]:
+                    if target.get("namespace") and target["namespace"]["name"] in env["namespaces"]:
                         # this target belongs to the environment
                         _add_component(
                             apps,


### PR DESCRIPTION
Fixes:

```
09:31:27   File "/var/lib/jenkins/workspace/project-koku-koku-pr-check/.bonfire_venv/lib64/python3.6/site-packages/bonfire/qontract.py", line 285, in get_apps_for_env
09:31:27     if target["namespace"]["name"] in env["namespaces"]:
09:31:27 TypeError: 'NoneType' object is not subscriptable
```

Turns out a deployment target can have a namespace set to `None`