### PR TITLE
Fetch ns describe urls from FE env spec, add keycloak admin info

### DIFF
--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -364,40 +364,33 @@ def describe_namespace(project_name: str):
     if not ns.operator_ns:
         raise FatalError(f"namespace '{project_name}' was not reserved with namespace operator")
 
-    routes = get_json("route", namespace=project_name)
-    host = get_fe_hostname(routes)
-
-    kc_name = f"env-{project_name}-keycloak"
-    fe_creds = get_keycloak_creds(get_json("secret", name=kc_name, namespace=project_name))
+    fe_host, keycloak_url = parse_fe_env(project_name)
+    fe_creds = get_keycloak_creds(project_name)
     output += f"Current project: {project_name}\n"
 
     project_url = get_console_url()
     if project_url:
         ns_url = f"{project_url}/k8s/cluster/projects/{project_name}"
         output += f"Console url: {ns_url}\n"
-    output += f"Frontend route: https://{host}\n"
-    output += f"Keycloak login: {fe_creds['username']} | {fe_creds['password']}\n"
+    output += f"Keycloak admin route: {keycloak_url}\n"
+    output += f"Keycloak admin login: {fe_creds['username']} | {fe_creds['password']}\n"
+    output += f"Frontend route: https://{fe_host}\n"
+    output += f"Frontend login: {fe_creds['defaultUsername']} | {fe_creds['defaultPassword']}\n"
     return output
 
 
-def get_fe_hostname(routes):
-    # Hostnames are all the same, so return the first one
-    return routes["items"][0]["spec"]["host"]
+def parse_fe_env(project_name):
+    fe_env = get_json("frontendenvironment", f"env-{project_name}")
+    fe_host = fe_env.get("spec", {}).get("hostname", "")
+    keycloak_url = fe_env.get("spec", {}).get("sso", "")
+    return fe_host, keycloak_url
 
 
-def get_default_keycloak_creds(keycloak_secret):
-    default_user = keycloak_secret["data"]["defaultUsername"]
-    default_pass = keycloak_secret["data"]["defaultPassword"]
-    plain_text_user = decode_b64(default_user)
-    plain_text_pass = decode_b64(default_pass)
-    return plain_text_user, plain_text_pass
-
-
-def get_keycloak_creds(keycloak_secret):
-    username, password = get_default_keycloak_creds(keycloak_secret)
+def get_keycloak_creds(project_name):
+    secret = get_json("secret", name=f"env-{project_name}-keycloak", namespace=project_name)
     kc_creds = {}
-    kc_creds["username"] = username
-    kc_creds["password"] = password
+    for key in ("username", "password", "defaultUsername", "defaultPassword"):
+        kc_creds[key] = decode_b64(secret["data"][key])
     return kc_creds
 
 

--- a/tests/test_bonfire.py
+++ b/tests/test_bonfire.py
@@ -286,14 +286,19 @@ def test_pool_list_command(mocker, caplog):
     assert output == fake_pools
 
 
-default_kc = {"username": "jdoe", "password": "password"}
+default_kc = {
+    "username": "admin",
+    "password": "adminPassword",
+    "defaultUsername": "jdoe",
+    "defaultPassword": "password",
+}
 eph_test_route = "env-ephemeral-blah-howdy.apps.c-rh-c-eph.8p0c.p1.openshiftapps.com"
 
 
 def test_describe_ephemeral_ns(mocker):
     mocker.patch("bonfire.namespaces.get_console_url", return_value="yes.redhat.com")
     mocker.patch("bonfire.namespaces.get_keycloak_creds", return_value=default_kc)
-    mocker.patch("bonfire.namespaces.get_fe_hostname", return_value=eph_test_route)
+    mocker.patch("bonfire.namespaces.parse_fe_env", return_value=(eph_test_route, "foo"))
     mocker.patch("bonfire.namespaces.get_json")
     mocker.patch("bonfire.namespaces.Namespace")
     runner = CliRunner()
@@ -308,7 +313,7 @@ def test_describe_ephemeral_ns(mocker):
 def test_describe_ephemeral_ns_from_ctx(mocker):
     mocker.patch("bonfire.namespaces.get_console_url", return_value="yes.redhat.com")
     mocker.patch("bonfire.namespaces.get_keycloak_creds", return_value=default_kc)
-    mocker.patch("bonfire.namespaces.get_fe_hostname", return_value=eph_test_route)
+    mocker.patch("bonfire.namespaces.parse_fe_env", return_value=(eph_test_route, "foo"))
     mocker.patch("bonfire.namespaces.get_json")
     mocker.patch("bonfire.namespaces.Namespace")
     mocker.patch("bonfire.bonfire.current_namespace_or_error", return_value="ephemeral-blah")
@@ -324,7 +329,7 @@ def test_describe_ephemeral_ns_from_ctx(mocker):
 def test_describe_default_ns(mocker):
     mocker.patch("bonfire.namespaces.get_console_url", return_value="yes.redhat.com")
     mocker.patch("bonfire.namespaces.get_keycloak_creds", return_value=default_kc)
-    mocker.patch("bonfire.namespaces.get_fe_hostname", return_value=eph_test_route)
+    mocker.patch("bonfire.namespaces.parse_fe_env", return_value=(eph_test_route, "foo"))
     mocker.patch("bonfire.namespaces.get_json")
     runner = CliRunner()
     try:


### PR DESCRIPTION
Since the keycloak auth route has a different hostname from the others, the logic of "print hostname for route 0" is incorrect. This changes `bonfire namespace describe` to fetch the FE URL and SSO URL from the FrontendEnvironment spec. Also we now include the keycloak admin URL/login info in the command output.