### PR TITLE
Path fix for sh

### DIFF
--- a/cicd/bootstrap.sh
+++ b/cicd/bootstrap.sh
@@ -6,7 +6,7 @@ set -e
 export CICD_REPO_BRANCH="${CICD_REPO_BRANCH:-main}"
 
 BOOTSTRAP_URL="https://raw.githubusercontent.com/RedHatInsights/cicd-tools/${CICD_REPO_BRANCH}/bootstrap.sh"
-BOOTSTRAP_FILE=".cicd_tools_bootstrap.sh"
+BOOTSTRAP_FILE="./.cicd_tools_bootstrap.sh"
 
 echo "Fetching $BOOTSTRAP_URL"
 rm -f $BOOTSTRAP_FILE

--- a/cicd/bootstrap.sh
+++ b/cicd/bootstrap.sh
@@ -3,13 +3,13 @@
 set -e
 
 # which branch to fetch cicd scripts from in cicd-tools repo
-export CICD_REPO_BRANCH="${CICD_REPO_BRANCH:-main}"
-
-BOOTSTRAP_URL="https://raw.githubusercontent.com/RedHatInsights/cicd-tools/${CICD_REPO_BRANCH}/bootstrap.sh"
+CICD_REPO_BRANCH="${CICD_REPO_BRANCH:-main}"
+CICD_REPO_ORG="${CICD_REPO_ORG:-RedHatInsights}"
+BOOTSTRAP_URL="https://raw.githubusercontent.com/${CICD_REPO_ORG}/cicd-tools/${CICD_REPO_BRANCH}/bootstrap.sh"
 BOOTSTRAP_FILE="./.cicd_tools_bootstrap.sh"
 
 echo "Fetching $BOOTSTRAP_URL"
 rm -f $BOOTSTRAP_FILE
-RESPONSE_CODE=$(curl --silent -w "%{http_code}" -o $BOOTSTRAP_FILE $BOOTSTRAP_URL)
+RESPONSE_CODE=$(curl --silent -w "%{http_code}" -o "$BOOTSTRAP_FILE" "$BOOTSTRAP_URL")
 echo "HTTP response: $RESPONSE_CODE"
-source $BOOTSTRAP_FILE
+source "$BOOTSTRAP_FILE"


### PR DESCRIPTION
- Fixes bug when sourcing dotfiles using relative paths on `sh` shells
- Adds variables to overwrite the Org and the branch from where the bootstrap script is pulled for debugging purposes.
