### PR TITLE
Update list of frontend dependencies

### DIFF
--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -57,6 +57,9 @@ BONFIRE_BOT = os.getenv("BONFIRE_BOT")
 AUTO_ADDED_FRONTEND_DEPENDENCIES = (
     "chrome-service",
     "frontend-configs",
+    "landing-page-frontend",
+    "insights-chrome",
+    "insights-dashboard",
     "rbac",
     "rbac-frontend",
     "host-inventory",

--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -56,7 +56,6 @@ BONFIRE_BOT = os.getenv("BONFIRE_BOT")
 
 AUTO_ADDED_FRONTEND_DEPENDENCIES = (
     "chrome-service",
-    "frontend-configs",
     "landing-page-frontend",
     "insights-chrome",
     "insights-dashboard",


### PR DESCRIPTION
Some of the Frontend configurations have been split out of `frontend-configs` (chrome, landing, and dashboard) into their own separate deployment config. This updates the list.