### PR TITLE
Override frontend auto-added dependencies with BONFIRE_FRONTEND_DEPENDENCIES env var

### DIFF
--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -54,7 +54,7 @@ BONFIRE_NS_REQUESTER = os.getenv("BONFIRE_NS_REQUESTER")
 # set to true when bonfire is running via automation using a bot acct (not an end user)
 BONFIRE_BOT = os.getenv("BONFIRE_BOT")
 
-AUTO_ADDED_FRONTEND_DEPENDENCIES = (
+DEFAULT_FRONTEND_DEPENDENCIES = (
     "chrome-service",
     "landing-page-frontend",
     "insights-chrome",
@@ -63,8 +63,21 @@ AUTO_ADDED_FRONTEND_DEPENDENCIES = (
     "rbac-frontend",
     "host-inventory",
     "host-inventory-frontend",
-    "unleash-proxy"
+    "unleash-proxy",
 )
+
+
+def _parse_frontend_dependencies():
+    env_var = os.getenv("BONFIRE_FRONTEND_DEPENDENCIES")
+    if isinstance(env_var, str):
+        if env_var.strip() == "":
+            return set()
+        return set(env_var.split(","))
+
+    return set(DEFAULT_FRONTEND_DEPENDENCIES)
+
+
+AUTO_ADDED_FRONTEND_DEPENDENCIES = _parse_frontend_dependencies()
 
 
 def write_default_config(outpath=None):

--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -67,17 +67,20 @@ DEFAULT_FRONTEND_DEPENDENCIES = (
 )
 
 
-def _parse_frontend_dependencies():
+def _get_auto_added_frontend_dependencies():
     env_var = os.getenv("BONFIRE_FRONTEND_DEPENDENCIES")
-    if isinstance(env_var, str):
-        if env_var.strip() == "":
-            return set()
-        return set(env_var.split(","))
+    result = set()
 
-    return set(DEFAULT_FRONTEND_DEPENDENCIES)
+    if env_var is None:
+        result = set(DEFAULT_FRONTEND_DEPENDENCIES)
+    elif env_var.strip() != "":
+        for app in env_var.split(","):
+            result.add(app.strip())
+
+    return result
 
 
-AUTO_ADDED_FRONTEND_DEPENDENCIES = _parse_frontend_dependencies()
+AUTO_ADDED_FRONTEND_DEPENDENCIES = _get_auto_added_frontend_dependencies()
 
 
 def write_default_config(outpath=None):

--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -69,15 +69,10 @@ DEFAULT_FRONTEND_DEPENDENCIES = (
 
 def _get_auto_added_frontend_dependencies():
     env_var = os.getenv("BONFIRE_FRONTEND_DEPENDENCIES")
-    result = set()
 
     if env_var is None:
-        result = set(DEFAULT_FRONTEND_DEPENDENCIES)
-    elif env_var.strip() != "":
-        for app in env_var.split(","):
-            result.add(app.strip())
-
-    return result
+        return set(DEFAULT_FRONTEND_DEPENDENCIES)
+    return set([val.strip() for val in env_var.split(",") if val.strip()])
 
 
 AUTO_ADDED_FRONTEND_DEPENDENCIES = _get_auto_added_frontend_dependencies()


### PR DESCRIPTION
This will allow teams (like HAC team) who don't need all these components pulled in to be able to customize the list by setting the env var, e.g.:

```
BONFIRE_FRONTEND_DEPENDENCIES="chrome-service,frontend-configs" bonfire deploy <args> --frontends=true
```

You can also pass an empty value which will cause no frontend dependencies to be pulled in automatically, e.g:
```
BONFIRE_FRONTEND_DEPENDENCIES="" bonfire deploy <args> --frontends=true
```