### PR TITLE
Type check SHA response

### DIFF
--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -330,6 +330,9 @@ class RepoFile:
             )
 
         response = self._get_ref(get_ref_func)
+        response_json = response.json()
+        if isinstance(response_json, list):
+            return response_json[0]["object"]["sha"]
         return response.json()["object"]["sha"]
 
     def _fetch_github(self):

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -333,7 +333,7 @@ class RepoFile:
         response_json = response.json()
         if isinstance(response_json, list):
             return response_json[0]["object"]["sha"]
-        return response.json()["object"]["sha"]
+        return response_json["object"]["sha"]
 
     def _fetch_github(self):
         commit = self.ref


### PR DESCRIPTION
This patch adds a type check on the response object when we get a SHA. it can sometimes be a list rather than a dict. 

We got this report and this should fix it:
```
2023-08-24 14:22:41 [   ERROR] [          MainThread] failed to fetch template file for service-accounts
2023-08-24 14:22:41 [   ERROR] [          MainThread] hit fatal error: list indices must be integers or slices, not str
2023-08-24 14:22:41 [    INFO] [          MainThread] releasing namespace 'ephemeral-x0cun8'
2023-08-24 14:22:42 [    INFO] [          MainThread] processing namespace reservation
2023-08-24 14:22:42 [    INFO] [          MainThread] running (pid 95686): oc apply -f -
2023-08-24 14:22:43 [    INFO] [           pid-95686]  |stdout| namespacereservation.cloud.redhat.com/bonfire-reservation-cf86f0d8 configured
2023-08-24 14:22:43 [    INFO] [          MainThread] releasing reservation 'bonfire-reservation-cf86f0d8' namespace 'ephemeral-x0cun8'
ERROR: deploy failed: list indices must be integers or slices, not str
```