### PR TITLE
Don't get reservation status for terminating namespaces

### DIFF
--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -226,6 +226,7 @@ class Namespace:
     def is_active(self):
         return self.phase == self.STATUS_ACTIVE
 
+
 def get_namespaces(available=False, mine=False):
     """
     Look up reservable namespaces in the cluster.

--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -215,16 +215,16 @@ class Namespace:
         return f"{ready}/{managed}"
 
     @property
-    def status(self):
+    def phase(self):
         return self._data.get("status", {}).get("phase", "")
-    
+
     @property
     def is_terminating(self):
-        return self.status == self.STATUS_TERMINATING
-    
+        return self.phase == self.STATUS_TERMINATING
+
     @property
     def is_active(self):
-        return self.status == self.STATUS_ACTIVE
+        return self.phase == self.STATUS_ACTIVE
 
 def get_namespaces(available=False, mine=False):
     """

--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -17,6 +17,7 @@ from bonfire.openshift import (
 from bonfire.processor import process_reservation
 from bonfire.utils import FatalError, hms_to_seconds
 
+
 log = logging.getLogger(__name__)
 TIME_FMT = "%Y-%m-%dT%H:%M:%SZ"
 
@@ -188,7 +189,7 @@ class Namespace:
 
         if not self._reservation or not self._reservation.get("status"):
             self._reservation = None
-            log.warning("could not retrieve reservation details for ns: %s", self.name)
+            log.debug("could not retrieve reservation details for ns: %s", self.name)
 
         return self._reservation
 

--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -67,8 +67,6 @@ def _duration_fmt(seconds):
         return "%ds" % (seconds,)
 
 
-
-
 class Namespace:
     STATUS_ACTIVE = "Active"
     STATUS_TERMINATING = "Terminating"

--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -68,8 +68,8 @@ def _duration_fmt(seconds):
 
 
 class Namespace:
-    STATUS_ACTIVE = "Active"
-    STATUS_TERMINATING = "Terminating"
+    PHASE_ACTIVE = "Active"
+    PHASE_TERMINATING = "Terminating"
 
     @property
     def annotations(self):
@@ -220,11 +220,11 @@ class Namespace:
 
     @property
     def is_terminating(self):
-        return self.phase == self.STATUS_TERMINATING
+        return self.phase == self.PHASE_TERMINATING
 
     @property
     def is_active(self):
-        return self.phase == self.STATUS_ACTIVE
+        return self.phase == self.PHASE_ACTIVE
 
 
 def get_namespaces(available=False, mine=False):


### PR DESCRIPTION
This patch addresses https://github.com/RedHatInsights/bonfire/issues/316 / RHCLOUD-27918

I looked at this for way too long thinking about all kinds of complex fixes (pass the logger in as a depdency so we can control its log level out at the click commands, split the list namespaces method up into mine and not mine methods to better control what we're doing at run time so we don't need to check reservation status on any !mine namespaces) but in the end I realized we should just do this, always have the log level in `Namespace.reservation` be debug. This information isn't useful to a normal bonfire user; devs or cluster admins can up the log level.