### PR TITLE
Handle image errors

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -48,6 +48,7 @@ from bonfire.utils import (
     split_equals,
     validate_time_string,
 )
+from ocviapy import StatusError
 
 log = logging.getLogger(__name__)
 
@@ -1205,6 +1206,9 @@ def _cmd_config_deploy(
         _err_handler(err)
     except FatalError as err:
         log.error("hit fatal error: %s", err)
+        _err_handler(err)
+    except StatusError as err:
+        log.error("hit status error: %s", err)
         _err_handler(err)
     except Exception as err:
         log.exception("hit unexpected error!")


### PR DESCRIPTION
This patch depends on https://github.com/RedHatInsights/ocviapy/pull/9

But unfortunately I can't get it to work. It looks like it should. I was testing with 

```
            "args": [
                "deploy",
                 "advisor",
                 "--set-image-tag", 
                 "quay.io/cloudservices/advisor-backend=324324",
            ],
```

in vscode but it never pops the `StatusError` and I can't figure out why. 