### PR TITLE
Use newly supported 'env' block in default IQE CJI template

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -335,25 +335,19 @@ def _validate_set_parameter(ctx, param, value):
         raise click.BadParameter("format must be '<component>/<param>=<value>'")
 
 
-def _validate_set_image_tag(ctx, param, value):
+def _validate_split_equals(ctx, param, value):
     try:
         return split_equals(value)
     except ValueError:
-        raise click.BadParameter("format must be '<image uri>=<tag>'")
-
-
-def _validate_set_preferred_params(ctx, param, value):
-    try:
-        return split_equals(value)
-    except ValueError:
-        raise click.BadParameter("format must be '<parameter name>=<value>'")
-
-
-def _validate_set_env_var(ctx, param, value):
-    try:
-        return split_equals(value)
-    except ValueError:
-        raise click.BadParameter("format must be 'ENV_VAR_NAME=<value>'")
+        msg = "format must be '<name>=<value>'"
+        name = param.name
+        if name == "set_image_tag":
+            msg = "format must be '<image uri>=<tag>', example: 'quay.io/org/repo=latest'"
+        elif name == "preferred_params":
+            msg = "format must be 'PARAMETER_NAME=value'"
+        elif name == "custom_env_vars":
+            msg = "format must be 'ENV_VAR_NAME=value'"
+        raise click.BadParameter(msg)
 
 
 def _validate_opposing_opts(ctx, param, value):
@@ -421,7 +415,7 @@ _app_source_options = [
         ),
         multiple=True,
         default=conf.BONFIRE_DEFAULT_PREFER,
-        callback=_validate_set_preferred_params,
+        callback=_validate_split_equals,
     ),
 ]
 
@@ -454,7 +448,7 @@ _process_options = _app_source_options + [
         "-i",
         help=("Override image tag for an image using format '<image uri>=<tag>'"),
         multiple=True,
-        callback=_validate_set_image_tag,
+        callback=_validate_split_equals,
     ),
     click.option(
         "--set-template-ref",
@@ -711,7 +705,7 @@ _iqe_cji_process_options = [
             "(can be specified multiple times)"
         ),
         multiple=True,
-        callback=_validate_set_env_var,
+        callback=_validate_split_equals,
     ),
     _local_option,
 ]

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -144,6 +144,7 @@ def process_iqe_cji(
     parallel_worker_count="",
     rp_args="",
     ibutsu_source="",
+    custom_env_vars=None,
 ):
     log.info("processing IQE ClowdJobInvocation")
 
@@ -177,6 +178,13 @@ def process_iqe_cji(
 
     if not processed_template.get("items"):
         raise FatalError("Processed CJI template has no items")
+
+    if custom_env_vars:
+        for resource in processed_template["items"]:
+            if resource.get("kind") == "ClowdJobInvocation":
+                env = resource.get("spec", {}).get("testing", {}).get("iqe", {}).get("env", [])
+                for var_name, var_value in custom_env_vars.items():
+                    env.append({"name": str(var_name), "value": str(var_value)})
 
     return processed_template
 

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -155,12 +155,8 @@ def process_iqe_cji(
     with template_path.open() as fp:
         template_data = yaml.safe_load(fp)
 
-    requirements = requirements.split(",") if requirements else []
-    requirements_priority = requirements_priority.split(",") if requirements_priority else []
-    test_importance = test_importance.split(",") if test_importance else []
-
     params = dict()
-    params["DEBUG"] = str(debug).lower()
+    params["DEBUG"] = json.dumps(debug)
     params["MARKER"] = marker
     params["FILTER"] = filter
     params["ENV_NAME"] = env
@@ -168,14 +164,14 @@ def process_iqe_cji(
     params["PLUGINS"] = plugins
     params["NAME"] = cji_name or f"iqe-{str(uuid.uuid4()).split('-')[0]}"
     params["APP_NAME"] = clowd_app_name
-    params["REQUIREMENTS"] = json.dumps(requirements)
-    params["REQUIREMENTS_PRIORITY"] = json.dumps(requirements_priority)
-    params["TEST_IMPORTANCE"] = json.dumps(test_importance)
+    params["REQUIREMENTS"] = requirements
+    params["REQUIREMENTS_PRIORITY"] = requirements_priority
+    params["TEST_IMPORTANCE"] = test_importance
     params["DEPLOY_SELENIUM"] = json.dumps(selenium)
-    params["PARALLEL_ENABLED"] = json.dumps(parallel_enabled)
-    params["PARALLEL_WORKER_COUNT"] = json.dumps(parallel_worker_count)
-    params["RP_ARGS"] = json.dumps(rp_args)
-    params["IBUTSU_SOURCE"] = json.dumps(ibutsu_source)
+    params["PARALLEL_ENABLED"] = parallel_enabled
+    params["PARALLEL_WORKER_COUNT"] = parallel_worker_count
+    params["RP_ARGS"] = rp_args
+    params["IBUTSU_SOURCE"] = ibutsu_source
 
     processed_template = _process_template(template_data, params=params, local=local)
 

--- a/bonfire/resources/default-iqe-cji.yaml
+++ b/bonfire/resources/default-iqe-cji.yaml
@@ -14,20 +14,32 @@ objects:
       iqe:
         debug: ${{DEBUG}}
         imageTag: ${IMAGE_TAG}
-        marker: ${MARKER}
-        filter: ${FILTER}
-        plugins: ${PLUGINS}
-        dynaconfEnvName: ${ENV_NAME}
-        requirements: ${{REQUIREMENTS}}
-        requirementsPriority: ${{REQUIREMENTS_PRIORITY}}
-        testImportance: ${{TEST_IMPORTANCE}}
-        parallelEnabled: ${{PARALLEL_ENABLED}}
-        parallelWorkerCount: ${{PARALLEL_WORKER_COUNT}}
-        rpArgs: ${{RP_ARGS}}
-        ibutsuSource: ${{IBUTSU_SOURCE}}
         ui:
           selenium:
             deploy: ${{DEPLOY_SELENIUM}}
+        env:
+          - name: IQE_MARKER_EXPRESSION
+            value: ${MARKER}
+          - name: IQE_FILTER_EXPRESSION
+            value: ${FILTER}
+          - name: IQE_PLUGINS
+            value: ${PLUGINS}
+          - name: ENV_FOR_DYNACONF
+            value: ${ENV_NAME}
+          - name: IQE_REQUIREMENTS
+            value: ${REQUIREMENTS}
+          - name: IQE_REQUIREMENTS_PRIORITY
+            value: ${REQUIREMENTS_PRIORITY}
+          - name: IQE_TEST_IMPORTANCE
+            value: ${TEST_IMPORTANCE}
+          - name: IQE_PARALLEL_ENABLED
+            value: ${PARALLEL_ENABLED}
+          - name: IQE_PARALLEL_WORKER_COUNT
+            value: ${PARALLEL_WORKER_COUNT}
+          - name: IQE_RP_ARGS
+            value: ${RP_ARGS}
+          - name: IQE_IBUTSU_SOURCE
+            value: ${IBUTSU_SOURCE}
 
 parameters:
 - name: NAME
@@ -46,11 +58,11 @@ parameters:
   value: "clowder_smoke"
   required: true
 - name: REQUIREMENTS
-  value: "[]"
+  value: ""
 - name: REQUIREMENTS_PRIORITY
-  value: "[]"
+  value: ""
 - name: TEST_IMPORTANCE
-  value: "[]"
+  value: ""
 - name: PLUGINS
   value: ""
 - name: DEPLOY_SELENIUM

--- a/tests/test_app_configs.py
+++ b/tests/test_app_configs.py
@@ -194,7 +194,7 @@ def test_local_no_remote_target_apps_found(monkeypatch, source, local_config_met
         fallback_ref_env=None,
         local_config_path="na",
         local_config_method=local_config_method,
-        prefer={},
+        preferred_params={},
     )
     assert actual == _target_apps()
 
@@ -225,7 +225,7 @@ def test_new_local_app_added_to_remote_apps(monkeypatch, source, local_config_me
         fallback_ref_env=None,
         local_config_path="na",
         local_config_method=local_config_method,
-        prefer={},
+        preferred_params={},
     )
     expected = _target_apps()
     expected["appC"] = local_cfg["apps"][0]
@@ -257,7 +257,7 @@ def test_new_local_component_merged(monkeypatch, source):
         fallback_ref_env=None,
         local_config_path="na",
         local_config_method="merge",
-        prefer={},
+        preferred_params={},
     )
     expected = _target_apps()
     expected["appB"]["components"].append(local_cfg["apps"][0]["components"][0])
@@ -276,7 +276,7 @@ def test_empty_local_config(monkeypatch, source, local_config_method):
         fallback_ref_env=None,
         local_config_path="na",
         local_config_method=local_config_method,
-        prefer={},
+        preferred_params={},
     )
     assert actual == _target_apps_w_refs_subbed()
 
@@ -306,7 +306,7 @@ def test_bad_local_config(monkeypatch, source, local_config_method, bad_local_cf
             fallback_ref_env=None,
             local_config_path="na",
             local_config_method=local_config_method,
-            prefer={},
+            preferred_params={},
         )
         assert str(exc).startswith(bonfire.utils.SYNTAX_ERR)
 
@@ -324,7 +324,7 @@ def test_master_branch_used_when_no_reference_app_found(monkeypatch, source, loc
         fallback_ref_env=None,
         local_config_path="na",
         local_config_method=local_config_method,
-        prefer={},
+        preferred_params={},
     )
 
     expected = _target_apps_w_refs_subbed()
@@ -348,7 +348,7 @@ def test_fallback_reference_env(monkeypatch, source, local_config_method):
         fallback_ref_env="test_ref_env",
         local_config_path="na",
         local_config_method=local_config_method,
-        prefer={},
+        preferred_params={},
     )
 
     assert apps_config == _target_apps_w_refs_subbed()
@@ -388,7 +388,7 @@ def test_local_config_merge(monkeypatch, source):
         fallback_ref_env=None,
         local_config_path="na",
         local_config_method="merge",
-        prefer={},
+        preferred_params={},
     )
 
     expected = _target_apps()
@@ -434,7 +434,7 @@ def test_local_config_override(monkeypatch, source):
         fallback_ref_env=None,
         local_config_path="na",
         local_config_method="override",
-        prefer={},
+        preferred_params={},
     )
 
     expected = _target_apps()
@@ -471,7 +471,7 @@ def test_local_config_merge_update_param(monkeypatch, source):
         fallback_ref_env=None,
         local_config_path="na",
         local_config_method="merge",
-        prefer={},
+        preferred_params={},
     )
 
     expected = _target_apps()


### PR DESCRIPTION
Second attempt at #329 --

* Changes the IQE CJI template to use the new `env` block introduced in https://github.com/RedHatInsights/clowder/pull/855
* Adds a `--env-var` CLI option to allow users to pass custom env vars to the IQE pod at runtime