### PR TITLE
Add fallback ref & preference rules for duplicate deployment targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ bonfire deploy advisor --set-image-tag quay.io/cloudservices/advisor-backend=my_
 * `--set-template-ref <component>=<ref>` -- use this to change the git ref deployed for just a single component.
 * `--set-parameter <component>/<name>=<value>` -- use this to set a parameter value on a specific component's template.
 * `--optional-deps-method <hybrid|all|none>` -- change the way that bonfire processes ClowdApp optional dependencies (see "Dependency Processing" section)
+* `--prefer PARAM_NAME=PARAM_VALUE` -- in cases where bonfire finds more than one deployment target, use this to set the parameter names and values that should be used to select a "preferred" deployment target. This option can be passed in multiple times. `bonfire` will select the target with the highest amount of "preferred parameters" on it. Default is currently set to `ENV=frontends` to select "stable" frontends in the consoledot environments.
 
 
 # Interactions with Ephemeral Namespace Operator

--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -58,6 +58,11 @@ BONFIRE_NS_REQUESTER = os.getenv("BONFIRE_NS_REQUESTER")
 BONFIRE_BOT = os.getenv("BONFIRE_BOT")
 
 BONFIRE_DEFAULT_PREFER = str(os.getenv("BONFIRE_DEFAULT_PREFER", "ENV_NAME=frontends")).split(",")
+BONFIRE_DEFAULT_REF_ENV = str(os.getenv("BONFIRE_DEFAULT_REF_ENV", "insights-stage"))
+BONFIRE_DEFAULT_FALLBACK_REF_ENV = str(
+    os.getenv("BONFIRE_DEFAULT_FALLBACK_REF_ENV", "insights-stage")
+)
+
 
 DEFAULT_FRONTEND_DEPENDENCIES = (
     "chrome-service",

--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -45,7 +45,10 @@ QONTRACT_USERNAME = os.getenv("QONTRACT_USERNAME", APP_INTERFACE_USERNAME or Non
 QONTRACT_PASSWORD = os.getenv("QONTRACT_PASSWORD", APP_INTERFACE_PASSWORD or None)
 QONTRACT_TOKEN = os.getenv("QONTRACT_TOKEN")
 
-BASE_NAMESPACE_NAME = os.getenv("BASE_NAMESPACE_NAME", "ephemeral-base")
+BASE_NAMESPACE_PATH = os.getenv(
+    "BASE_NAMESPACE_PATH",
+    "/services/insights/ephemeral/namespaces/ephemeral-base.yml",
+)
 EPHEMERAL_ENV_NAME = os.getenv("EPHEMERAL_ENV_NAME", "insights-ephemeral")
 ENV_NAME_FORMAT = os.getenv("ENV_NAME_FORMAT", "env-{namespace}")
 
@@ -53,6 +56,8 @@ ENV_NAME_FORMAT = os.getenv("ENV_NAME_FORMAT", "env-{namespace}")
 BONFIRE_NS_REQUESTER = os.getenv("BONFIRE_NS_REQUESTER")
 # set to true when bonfire is running via automation using a bot acct (not an end user)
 BONFIRE_BOT = os.getenv("BONFIRE_BOT")
+
+BONFIRE_DEFAULT_PREFER = str(os.getenv("BONFIRE_DEFAULT_PREFER", "ENV_NAME=frontends")).split(",")
 
 DEFAULT_FRONTEND_DEPENDENCIES = (
     "chrome-service",

--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -382,8 +382,8 @@ def describe_namespace(project_name: str):
 
     frontends = get_json("frontend", namespace=project_name)
     clowdapps = get_json("clowdapp", namespace=project_name)
-    num_frontends = len(frontends.get('items', []))
-    num_clowdapps = len(clowdapps.get('items', []))
+    num_frontends = len(frontends.get("items", []))
+    num_clowdapps = len(clowdapps.get("items", []))
     fe_host, keycloak_url = parse_fe_env(project_name)
     kc_creds = get_keycloak_creds(project_name)
     project_url = get_console_url()
@@ -394,10 +394,7 @@ def describe_namespace(project_name: str):
         output += f"Project URL: {ns_url}\n"
     output += f"Keycloak admin route: {keycloak_url}\n"
     output += f"Keycloak admin login: {kc_creds['username']} | {kc_creds['password']}\n"
-    output += (
-        f"{num_clowdapps} ClowdApp(s), "
-        f"{num_frontends} Frontend(s) deployed\n"
-    )
+    output += f"{num_clowdapps} ClowdApp(s), " f"{num_frontends} Frontend(s) deployed\n"
     output += f"Gateway route: https://{fe_host}\n"
     output += f"Default user login: {kc_creds['defaultUsername']} | {kc_creds['defaultPassword']}\n"
 

--- a/bonfire/qontract.py
+++ b/bonfire/qontract.py
@@ -26,6 +26,7 @@ ENVS_QUERY = gql(
         parameters
         namespaces {
           name
+          path
         }
       }
     }
@@ -52,6 +53,7 @@ APPS_QUERY = gql(
             targets {
               namespace {
                 name
+                path
                 cluster {
                   name
                 }
@@ -59,22 +61,6 @@ APPS_QUERY = gql(
               ref
               parameters
             }
-          }
-        }
-      }
-    }
-    """
-)
-
-NAMESPACE_QUERY = gql(
-    """
-    {
-      namespaces: namespaces_v1 {
-        name
-        openshiftResources {
-          ... on NamespaceOpenshiftResourceVaultSecret_v1 {
-            name
-            path
           }
         }
       }
@@ -108,7 +94,7 @@ class Client:
         """Get insights env configuration."""
         for env_data in self.client.execute(ENVS_QUERY)["envs"]:
             if env_data["name"] == env:
-                env_data["namespaces"] = set(n["name"] for n in env_data["namespaces"])
+                env_data["namespaces"] = {ns["path"]: ns["name"] for ns in env_data["namespaces"]}
                 break
         else:
             raise ValueError(f"cannot find env '{env}'")
@@ -117,11 +103,6 @@ class Client:
 
     def get_apps(self):
         return self.client.execute(APPS_QUERY)["apps"]
-
-    def get_namespace(self, name):
-        for ns in self.client.execute(NAMESPACE_QUERY)["namespaces"]:
-            if ns["name"] == name:
-                return ns
 
 
 _client = None
@@ -145,63 +126,75 @@ def _find_matching_component(apps, app_name, component_name):
             return component
 
 
-def _check_replace_other(other_params, this_params):
-    this_clowder_enabled = bool(this_params.get("CLOWDER_ENABLED"))
-    other_clowder_enabled = bool(other_params.get("CLOWDER_ENABLED"))
-    if this_clowder_enabled and not other_clowder_enabled:
-        return True
+def _check_replace_other(other_params, this_params, preferred_params):
+    """
+    Compare parameters of "this" component with parameters of the "other" component.
+    Assign points to the component if it is using a preferred parameter value. The component
+    with the higher number of points will be selected.
+    """
+    this_weight = 0
+    other_weight = 0
 
-    this_replicas = int(this_params.get("REPLICAS", 1))
-    other_replicas = int(other_params.get("REPLICAS", 1))
-    if other_replicas < 1 and this_replicas > 1:
-        return True
+    # prefer deployment targets that have CLOWDER_ENABLED=true
+    # TODO: a relic of the past and at this point probably no longer needed, remove in a follow-up
+    preferred_params["CLOWDER_ENABLED"] = preferred_params.get("CLOWDER_ENABLED", "true")
 
-    this_replicas = int(this_params.get("MIN_REPLICAS", 1))
-    other_replicas = int(other_params.get("MIN_REPLICAS", 1))
-    if other_replicas < 1 and this_replicas > 1:
+    # check if target is configured with preferred parameters
+    for param_name, param_value in preferred_params.items():
+        if str(this_params.get(param_name)).lower() == str(param_value).lower():
+            log.debug("    `-- 'this' weight +1 for %s=%s", param_name, param_value)
+            this_weight += 1
+        if str(other_params.get(param_name)).lower() == str(param_value).lower():
+            log.debug("    `-- 'other' weight +1 for %s=%s", param_name, param_value)
+            other_weight += 1
+
+    # prefer deployment targets that have REPLICAS >= 1
+    for param_name in ("REPLICAS", "MIN_REPLICAS"):
+        this_replicas = int(this_params.get(param_name, 0))
+        other_replicas = int(other_params.get(param_name, 0))
+        if this_replicas >= 1:
+            log.debug("    `-- 'this' weight +1 for %s>=1", param_name)
+            this_weight += 1
+        if other_replicas >= 1:
+            log.debug("    `-- 'other' weight +1 for %s>=1", param_name)
+            other_weight += 1
+
+    log.debug("    `-- final: 'this' weight: %d, 'other' weight: %d", this_weight, other_weight)
+
+    if this_weight > other_weight:
         return True
 
     return False
 
 
 def _add_component_if_priority_higher(
-    apps, app_name, component_name, env_name, saas_file, component, defined_multiple
+    apps,
+    app_name,
+    component_name,
+    component,
+    defined_multiple,
+    preferred_params,
 ):
-    add_component = True
     existing_match = _find_matching_component(apps, app_name, component_name)
-
-    if existing_match:
+    if not existing_match:
+        apps[app_name]["name"] = app_name
+        apps[app_name]["components"].append(component)
+    else:
         # this app/component is defined multiple times in the environment
         # look at the parameters set on it to decide which definition to prioritize
         defined_multiple.add((app_name, component_name))
         other_params = existing_match["parameters"]
         this_params = component["parameters"]
-        add_component = _check_replace_other(other_params, this_params)
-        if add_component:
-            log.debug(
-                "app: '%s' component: '%s' defined in saas file '%s' takes priority",
-                app_name,
-                component_name,
-                saas_file["path"],
-            )
-        else:
-            log.debug(
-                "app: '%s' component: '%s' defined in saas file '%s' has lower priority, skipped",
-                app_name,
-                component_name,
-                saas_file["path"],
-            )
+        log.debug("  `-- this is a duplicate target, checking if this replaces existing other")
 
-    if add_component:
-        apps[app_name]["name"] = app_name
-        apps[app_name]["components"].append(component)
-        log.debug(
-            "app: '%s' component: '%s' added for env '%s' using saas file: %s",
-            app_name,
-            component_name,
-            env_name,
-            saas_file["name"],
-        )
+        replace = _check_replace_other(other_params, this_params, preferred_params)
+
+        if replace:
+            log.debug("  `-- this is weighted higher, replaces other")
+            apps[app_name]["components"].remove(existing_match)
+            apps[app_name]["components"].append(component)
+        else:
+            log.debug("  `-- this is weighted equal/lower, not replacing")
 
 
 def _process_env_parameters(parameters):
@@ -219,9 +212,17 @@ def _process_env_parameters(parameters):
                     )
 
 
-def _add_component(apps, env, app_name, saas_file, resource_template, target, defined_multiple):
+def _add_component(
+    apps,
+    env,
+    app_name,
+    saas_file,
+    resource_template,
+    target,
+    defined_multiple,
+    preferred_params,
+):
     component_name = resource_template["name"]
-    env_name = env["name"]
     saas_file_path = saas_file["path"]
 
     if app_name not in apps:
@@ -257,18 +258,23 @@ def _add_component(apps, env, app_name, saas_file, resource_template, target, de
     }
 
     _add_component_if_priority_higher(
-        apps, app_name, component_name, env_name, saas_file, component, defined_multiple
+        apps,
+        app_name,
+        component_name,
+        component,
+        defined_multiple,
+        preferred_params,
     )
 
 
-def get_apps_for_env(env_name):
+def get_apps_for_env(env_name, preferred_params):
     client = get_client()
     all_apps = client.get_apps()
     env = client.get_env(env_name)
 
     # work-around to only show apps with an ephemeral deploy target
     if env_name == conf.EPHEMERAL_ENV_NAME:
-        env["namespaces"] = [conf.BASE_NAMESPACE_NAME]
+        env["namespaces"] = [conf.BASE_NAMESPACE_PATH]
 
     apps = {}
     ignored_apps = set()
@@ -280,19 +286,38 @@ def get_apps_for_env(env_name):
             continue
         saas_files = app.get("saasFiles", [])
         for saas_file in saas_files:
-            for resource_template in saas_file.get("resourceTemplates", []):
-                for target in resource_template.get("targets", []):
-                    if target.get("namespace") and target["namespace"]["name"] in env["namespaces"]:
-                        # this target belongs to the environment
-                        _add_component(
-                            apps,
-                            env,
-                            app["name"],
-                            saas_file,
-                            resource_template,
-                            target,
-                            defined_multiple,
-                        )
+            for rt_idx, resource_template in enumerate(saas_file.get("resourceTemplates", [])):
+                for target_idx, target in enumerate(resource_template.get("targets", [])):
+                    ns = target.get("namespace") or {}
+                    ns_name = ns.get("name")
+                    ns_path = ns.get("path")
+                    if ns_path not in env["namespaces"]:
+                        # this deploy target ns is not in the environment
+                        continue
+                    # this target ns belongs to the environment
+                    log.debug(
+                        "app '%s' component '%s' found in saas file '%s'",
+                        app["name"],
+                        resource_template["name"],
+                        saas_file["path"],
+                    )
+                    log.debug(
+                        "  position: .resourceTemplates[%d].targets[%d] (env '%s', ns '%s')",
+                        rt_idx,
+                        target_idx,
+                        env_name,
+                        ns_name,
+                    )
+                    _add_component(
+                        apps,
+                        env,
+                        app["name"],
+                        saas_file,
+                        resource_template,
+                        target,
+                        defined_multiple,
+                        preferred_params,
+                    )
 
     if ignored_apps:
         log.debug(
@@ -312,8 +337,8 @@ def get_apps_for_env(env_name):
     return apps
 
 
-def sub_refs(apps, ref_env_name):
-    ref_env_apps = get_apps_for_env(ref_env_name)
+def sub_refs(apps, ref_env_name, preferred_params):
+    ref_env_apps = get_apps_for_env(ref_env_name, preferred_params)
 
     final_apps = copy.deepcopy(apps)
     for app_name, app in apps.items():
@@ -351,26 +376,3 @@ def sub_refs(apps, ref_env_name):
                 final_apps[app_name]["components"][idx]["ref"] = "master"
 
     return final_apps
-
-
-def get_namespaces_for_env(environment_name):
-    client = get_client()
-
-    namespaces = client.get_env(environment_name)["namespaces"]
-    results = list(namespaces)
-    log.debug("namespaces listed in qontract for environment '%s': %s", environment_name, results)
-    return results
-
-
-def get_secret_names_in_namespace(namespace_name):
-    client = get_client()
-
-    secret_names = []
-    namespace = client.get_namespace(namespace_name)
-    for resource in namespace["openshiftResources"]:
-        if not resource:
-            # query returns {} if resource is not 'NamespaceOpenshiftResourceVaultSecret_v1'
-            continue
-        name = resource["name"] or resource["path"].split("/")[-1]
-        secret_names.append(name)
-    return secret_names

--- a/tests/test_app_configs.py
+++ b/tests/test_app_configs.py
@@ -155,7 +155,7 @@ def _target_apps_w_refs_subbed():
     }
 
 
-def _mock_get_apps_for_env(env):
+def _mock_get_apps_for_env(env, preferred_params):
     if env is None or env == "test_env_with_no_apps":
         return {}
     elif env == "test_target_env":
@@ -193,6 +193,7 @@ def test_local_no_remote_target_apps_found(monkeypatch, source, local_config_met
         ref_env=None,
         local_config_path="na",
         local_config_method=local_config_method,
+        prefer={},
     )
     assert actual == _target_apps()
 
@@ -222,6 +223,7 @@ def test_new_local_app_added_to_remote_apps(monkeypatch, source, local_config_me
         ref_env=None,
         local_config_path="na",
         local_config_method=local_config_method,
+        prefer={},
     )
     expected = _target_apps()
     expected["appC"] = local_cfg["apps"][0]
@@ -252,6 +254,7 @@ def test_new_local_component_merged(monkeypatch, source):
         ref_env=None,
         local_config_path="na",
         local_config_method="merge",
+        prefer={},
     )
     expected = _target_apps()
     expected["appB"]["components"].append(local_cfg["apps"][0]["components"][0])
@@ -269,6 +272,7 @@ def test_empty_local_config(monkeypatch, source, local_config_method):
         ref_env="test_ref_env",
         local_config_path="na",
         local_config_method=local_config_method,
+        prefer={},
     )
     assert actual == _target_apps_w_refs_subbed()
 
@@ -297,6 +301,7 @@ def test_bad_local_config(monkeypatch, source, local_config_method, bad_local_cf
             ref_env=None,
             local_config_path="na",
             local_config_method=local_config_method,
+            prefer={},
         )
         assert str(exc).startswith(bonfire.utils.SYNTAX_ERR)
 
@@ -313,6 +318,7 @@ def test_master_branch_used_when_no_reference_app_found(monkeypatch, source, loc
         ref_env="test_env_with_no_apps",
         local_config_path="na",
         local_config_method=local_config_method,
+        prefer={},
     )
 
     expected = _target_apps_w_refs_subbed()
@@ -356,6 +362,7 @@ def test_local_config_merge(monkeypatch, source):
         ref_env=None,
         local_config_path="na",
         local_config_method="merge",
+        prefer={},
     )
 
     expected = _target_apps()
@@ -400,6 +407,7 @@ def test_local_config_override(monkeypatch, source):
         ref_env=None,
         local_config_path="na",
         local_config_method="override",
+        prefer={},
     )
 
     expected = _target_apps()
@@ -435,6 +443,7 @@ def test_local_config_merge_update_param(monkeypatch, source):
         ref_env=None,
         local_config_path="na",
         local_config_method="merge",
+        prefer={},
     )
 
     expected = _target_apps()

--- a/tests/test_app_configs.py
+++ b/tests/test_app_configs.py
@@ -191,6 +191,7 @@ def test_local_no_remote_target_apps_found(monkeypatch, source, local_config_met
         source=source,
         target_env="test_env_with_no_apps",
         ref_env=None,
+        fallback_ref_env=None,
         local_config_path="na",
         local_config_method=local_config_method,
         prefer={},
@@ -221,6 +222,7 @@ def test_new_local_app_added_to_remote_apps(monkeypatch, source, local_config_me
         source=source,
         target_env="test_target_env",
         ref_env=None,
+        fallback_ref_env=None,
         local_config_path="na",
         local_config_method=local_config_method,
         prefer={},
@@ -252,6 +254,7 @@ def test_new_local_component_merged(monkeypatch, source):
         source=source,
         target_env="test_target_env",
         ref_env=None,
+        fallback_ref_env=None,
         local_config_path="na",
         local_config_method="merge",
         prefer={},
@@ -270,6 +273,7 @@ def test_empty_local_config(monkeypatch, source, local_config_method):
         source=source,
         target_env="test_target_env",
         ref_env="test_ref_env",
+        fallback_ref_env=None,
         local_config_path="na",
         local_config_method=local_config_method,
         prefer={},
@@ -299,6 +303,7 @@ def test_bad_local_config(monkeypatch, source, local_config_method, bad_local_cf
             source=source,
             target_env="test_env_with_no_apps",
             ref_env=None,
+            fallback_ref_env=None,
             local_config_path="na",
             local_config_method=local_config_method,
             prefer={},
@@ -316,6 +321,7 @@ def test_master_branch_used_when_no_reference_app_found(monkeypatch, source, loc
         source=source,
         target_env="test_target_env",
         ref_env="test_env_with_no_apps",
+        fallback_ref_env=None,
         local_config_path="na",
         local_config_method=local_config_method,
         prefer={},
@@ -327,6 +333,25 @@ def test_master_branch_used_when_no_reference_app_found(monkeypatch, source, loc
             component["ref"] = "master"
 
     assert apps_config == expected
+
+
+@pytest.mark.parametrize("local_config_method", ("merge", "override"))
+@pytest.mark.parametrize("source", (APP_SRE_SRC, FILE_SRC))
+def test_fallback_reference_env(monkeypatch, source, local_config_method):
+    local_cfg = {}
+    _setup_monkeypatch(monkeypatch, source, local_cfg)
+
+    apps_config = _get_apps_config(
+        source=source,
+        target_env="test_target_env",
+        ref_env="test_env_with_no_apps",
+        fallback_ref_env="test_ref_env",
+        local_config_path="na",
+        local_config_method=local_config_method,
+        prefer={},
+    )
+
+    assert apps_config == _target_apps_w_refs_subbed()
 
 
 @pytest.mark.parametrize("source", (APP_SRE_SRC, FILE_SRC))
@@ -360,6 +385,7 @@ def test_local_config_merge(monkeypatch, source):
         source=source,
         target_env="test_target_env",
         ref_env=None,
+        fallback_ref_env=None,
         local_config_path="na",
         local_config_method="merge",
         prefer={},
@@ -405,6 +431,7 @@ def test_local_config_override(monkeypatch, source):
         source=source,
         target_env="test_target_env",
         ref_env=None,
+        fallback_ref_env=None,
         local_config_path="na",
         local_config_method="override",
         prefer={},
@@ -441,6 +468,7 @@ def test_local_config_merge_update_param(monkeypatch, source):
         source=source,
         target_env="test_target_env",
         ref_env=None,
+        fallback_ref_env=None,
         local_config_path="na",
         local_config_method="merge",
         prefer={},

--- a/tests/test_get_apps.py
+++ b/tests/test_get_apps.py
@@ -1,0 +1,226 @@
+import bonfire
+from bonfire.qontract import get_apps_for_env, sub_refs, ENVS_QUERY, APPS_QUERY
+
+
+def _mock_envs_gql_resp():
+    return {
+        "envs": [
+            {
+                "name": "ephemeral",
+                "parameters": '{"PARAM_1":"ephemeral1","PARAM_2":"ephemeral2","PARAM_3":100}',
+                "namespaces": [
+                    {"name": "ephemeral-base", "path": "/path/to/ephemeral-base.yml"},
+                ],
+            },
+            {
+                "name": "stage",
+                "parameters": '{"PARAM_1":"stage1","PARAM_2":"stage2","PARAM_3":200}',
+                "namespaces": [
+                    {"name": "stage-namespace-1", "path": "/path/to/stage-namespace-1.yml"},
+                    {"name": "stage-namespace-2", "path": "/path/to/stage-namespace-2.yml"},
+                    {"name": "stage-namespace-3", "path": "/path/to/stage-namespace-3.yml"},
+                ],
+            },
+            {
+                "name": "prod",
+                "parameters": '{"PARAM_1":"prod1","PARAM_2":"prod2","PARAM_3":300}',
+                "namespaces": [
+                    {"name": "prod-namespace-1", "path": "/path/to/prod-namespace-1.yml"},
+                    {"name": "prod-namespace-2", "path": "/path/to/prod-namespace-2.yml"},
+                ],
+            },
+        ]
+    }
+
+
+def _mock_apps_gql_resp():
+    return {
+        "apps": [
+            {
+                "name": "app1",
+                "parentApp": {"name": "insights"},
+                "saasFiles": [
+                    {
+                        "path": "/path/to/deploy.yml",
+                        "name": "app1",
+                        "parameters": None,
+                        "resourceTemplates": [
+                            {
+                                "name": "component1",
+                                "path": "/deploy/template.yml",
+                                "url": "https://github.test/Org/Repo",
+                                "parameters": None,
+                                "targets": [
+                                    {
+                                        "namespace": {
+                                            "name": "app1-stage-ns-1",
+                                            "path": "/path/to/stage-namespace-1.yml",
+                                            "cluster": {"name": "test_cluster"},
+                                        },
+                                        "ref": "master",
+                                        "parameters": None,
+                                    },
+                                    {
+                                        "namespace": {
+                                            "name": "app1-stage-ns-2",
+                                            "path": "/path/to/stage-namespace-2.yml",
+                                            "cluster": {"name": "test_cluster"},
+                                        },
+                                        "ref": "abc1234",
+                                        "parameters": '{"FAVORED_PARAM":"favored.value"}',
+                                    },
+                                    {
+                                        "namespace": {
+                                            "name": "app1-stage-ns-3",
+                                            "path": "/path/to/stage-namespace-3.yml",
+                                            "cluster": {"name": "test_cluster"},
+                                        },
+                                        "ref": "xyz6789",
+                                        "parameters": '{"FAVORED_PARAM":"unfavored.value"}',
+                                    },
+                                    {
+                                        "namespace": {
+                                            "name": "app1-prod-ns-1",
+                                            "path": "/path/to/prod-namespace-2.yml",
+                                            "cluster": {"name": "test_cluster"},
+                                        },
+                                        "ref": "prod1ref",
+                                        "parameters": '{"REPLICAS":1,"FAVORED_PARAM":"favored"}',
+                                    },
+                                    {
+                                        "namespace": {
+                                            "name": "app1-prod-ns-2",
+                                            "path": "/path/to/prod-namespace-2.yml",
+                                            "cluster": {"name": "test_cluster"},
+                                        },
+                                        "ref": "prod2ref",
+                                        "parameters": '{"REPLICAS":0,"FAVORED_PARAM":"favored"}',
+                                    },
+                                    {
+                                        "namespace": {
+                                            "name": "ephemeral-base",
+                                            "path": "/path/to/ephemeral-base.yml",
+                                            "cluster": {"name": "test_cluster"},
+                                        },
+                                        "ref": "internal",
+                                        "parameters": None,
+                                    },
+                                ],
+                            },
+                        ],
+                    }
+                ],
+            },
+        ]
+    }
+
+
+class MockGQLClient:
+    def execute(self, query):
+        if query == ENVS_QUERY:
+            return _mock_envs_gql_resp()
+        elif query == APPS_QUERY:
+            return _mock_apps_gql_resp()
+        else:
+            raise ValueError("invalid query for MockGQLClient")
+
+
+class MockAppInterfaceClient(bonfire.qontract.Client):
+    def __init__(self):
+        self.client = MockGQLClient()
+
+
+def _mock_get_client():
+    return MockAppInterfaceClient()
+
+
+def test_no_pref(monkeypatch):
+    """
+    Test that with no preference, git ref from first stage target is chosen
+    """
+    monkeypatch.setattr(bonfire.qontract, "get_client", _mock_get_client)
+    expected_apps = {
+        "app1": {
+            "name": "app1",
+            "components": [
+                {
+                    "name": "component1",
+                    "path": "/deploy/template.yml",
+                    "host": "github",
+                    "repo": "Org/Repo",
+                    "ref": "master",
+                    "parameters": {
+                        "PARAM_1": "ephemeral1",
+                        "PARAM_2": "ephemeral2",
+                        "PARAM_3": 100,
+                    },
+                }
+            ],
+        }
+    }
+    ephemeral_apps = get_apps_for_env(env_name="ephemeral", preferred_params={})
+    final_apps = sub_refs(ephemeral_apps, "stage", preferred_params={})
+
+    assert final_apps == expected_apps
+
+
+def test_preferred_ref(monkeypatch):
+    """
+    Test that git ref from stage target with FAVORED_PARAM=favored.value is chosen
+    """
+    monkeypatch.setattr(bonfire.qontract, "get_client", _mock_get_client)
+    expected_apps = {
+        "app1": {
+            "name": "app1",
+            "components": [
+                {
+                    "name": "component1",
+                    "path": "/deploy/template.yml",
+                    "host": "github",
+                    "repo": "Org/Repo",
+                    "ref": "abc1234",
+                    "parameters": {
+                        "PARAM_1": "ephemeral1",
+                        "PARAM_2": "ephemeral2",
+                        "PARAM_3": 100,
+                    },
+                }
+            ],
+        }
+    }
+    prefer = {"FAVORED_PARAM": "favored.value"}
+    ephemeral_apps = get_apps_for_env(env_name="ephemeral", preferred_params=prefer)
+    final_apps = sub_refs(ephemeral_apps, "stage", preferred_params=prefer)
+
+    assert final_apps == expected_apps
+
+
+def test_prefer_replicas(monkeypatch):
+    """
+    Test that git ref from prod target with REPLICAS=1 is chosen
+    """
+    monkeypatch.setattr(bonfire.qontract, "get_client", _mock_get_client)
+    expected_apps = {
+        "app1": {
+            "name": "app1",
+            "components": [
+                {
+                    "name": "component1",
+                    "path": "/deploy/template.yml",
+                    "host": "github",
+                    "repo": "Org/Repo",
+                    "ref": "prod1ref",
+                    "parameters": {
+                        "PARAM_1": "ephemeral1",
+                        "PARAM_2": "ephemeral2",
+                        "PARAM_3": 100,
+                    },
+                }
+            ],
+        }
+    }
+    prefer = {"FAVORED_PARAM": "favored"}
+    ephemeral_apps = get_apps_for_env(env_name="ephemeral", preferred_params=prefer)
+    final_apps = sub_refs(ephemeral_apps, "prod", preferred_params=prefer)
+
+    assert final_apps == expected_apps


### PR DESCRIPTION
The new containerized frontend apps have two deployment targets configured in the same environment -- a 'stable' target and a 'beta' target. Because of this, bonfire doesn't know which one to select when a user indicates something like `--ref-env=insights-stage` -- the deployment config from `insights-stage` that it selects to use for the git ref/image tag to deploy can be unpredictable.

Also, when bonfire is run with no `--ref-env`, it defaults to pulling from 'main/master' for all components. This isn't ideal for the frontend deployments which are pushing their betas into the main/master branch.

This PR:
* Sets the default `--ref-env` to be 'insights-stage' (can be changed with an env var). For backends, this should have basically no impact, because nearly every stage deployment target is using `master/main` already anyways.
* Adds a '--fallback-ref-env' argument. If we can't find a component's deployment config in the ref env, we will attempt to find it in the fallback ref env (by default this is 'insights-stage', but can be changed with an env var). If both the ref env and the fallback are the same, we don't bother analyzing the fallback env.
* Adds a '--prefer' argument that allows users to customize how the bonfire "duplicate deploy target" preference logic works. For example, you can use `bonfire deploy host-inventory --frontends=true --ref-env=insights-stage --prefer ENV_NAME=frontends-beta` to prefer beta deployment targets. You can use `--prefer` multiple times if for some reason you wish to specify multiple parameters.
* Changes the logic of `_check_replace_other` to use a number weighted system, and takes the `--prefer` input into account.  Also, I noticed the 'replicas' logic needed a tweak, went ahead and updated it here.
* Sets the default for `--prefer` to be `ENV_NAME=frontends` -- which would prefer consoledot stable frontend deployments.
* Enhances the logging related to how the app/component list is built
* Fixes a bug I found related to how we match namespaces to an environment. Some namespaces have the same name across environments or clusters. So we should match on the full namespace path in app-interface instead of just the name.