### PR TITLE
Add handling for bonfire.dependencies annotation

### DIFF
--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -13,7 +13,9 @@ from sh import ErrorReturnCode
 import bonfire.config as conf
 from bonfire.openshift import whoami
 from bonfire.utils import FatalError, RepoFile
+from bonfire.utils import get_clowdapp_dependencies
 from bonfire.utils import get_dependencies as utils_get_dependencies
+
 
 log = logging.getLogger(__name__)
 
@@ -586,15 +588,19 @@ class TemplateProcessor:
         if processed_component.deps_handled:
             log.debug("already handled dependencies for component '%s'", component_name)
         else:
-            dependencies_for_app = utils_get_dependencies(items)
+            # check ClowdApp dependencies
+            dependencies_for_app = get_clowdapp_dependencies(items)
             for _, deps in dependencies_for_app.items():
                 all_dependencies = all_dependencies.union(deps)
+            # check bonfire.dependencies annotations
+            all_dependencies.update(utils_get_dependencies(items))
             processed_component.deps_handled = True
 
         if processed_component.optional_deps_handled:
             log.debug("already handled optionalDependencies for component '%s'", component_name)
         elif self._should_fetch_optional_deps(app_name, component_name, in_recursion):
-            dependencies_for_app = utils_get_dependencies(items, optional=True)
+            # check ClowdApp optionalDependencies
+            dependencies_for_app = get_clowdapp_dependencies(items, optional=True)
             for _, deps in dependencies_for_app.items():
                 all_dependencies = all_dependencies.union(deps)
             processed_component.optional_deps_handled = True

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -383,7 +383,7 @@ def get_dependencies(items, optional=False):
     clowdapp_items = [item for item in items if item.get("kind").lower() == "clowdapp"]
 
     deps_for_app = dict()
-    
+
     for clowdapp in clowdapp_items:
         name = clowdapp["metadata"]["name"]
         dependencies = {d for d in clowdapp["spec"].get(key, [])}

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -383,12 +383,18 @@ def get_dependencies(items, optional=False):
     clowdapp_items = [item for item in items if item.get("kind").lower() == "clowdapp"]
 
     deps_for_app = dict()
-
+    
     for clowdapp in clowdapp_items:
         name = clowdapp["metadata"]["name"]
         dependencies = {d for d in clowdapp["spec"].get(key, [])}
         log.debug("clowdapp '%s' has %s: %s", name, key, list(dependencies))
         deps_for_app[name] = dependencies
+
+    for item in items:
+        name = item.get("metadata", {}).get("name")
+        bonfire_deps = list(filter(lambda x: x != '', item.get("metadata", {}).get("annotations",{}).get("bonfire.dependencies","").split(',')))
+        if name and bonfire_deps:
+            deps_for_app[name].update(bonfire_deps)
 
     return deps_for_app
 

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -392,9 +392,10 @@ def get_dependencies(items, optional=False):
 
     for item in items:
         name = item.get("metadata", {}).get("name")
-        bonfire_deps = list(filter(lambda x: x != '', item.get("metadata", {}).get("annotations",{}).get("bonfire.dependencies","").split(',')))
-        if name and bonfire_deps:
-            deps_for_app[name].update(bonfire_deps)
+        bonfire_deps = item.get("metadata", {}).get("annotations",{}).get("bonfire.dependencies","").split(',')
+        filtered_bonfire_deps = list(filter(lambda x: x != '', bonfire_deps))
+        if name and filtered_bonfire_deps:
+            deps_for_app[name].update(filtered_bonfire_deps)
 
     return deps_for_app
 

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -391,10 +391,10 @@ def get_dependencies(items, optional=False):
         deps_for_app[name] = dependencies
 
     for item in items:
-        name = item.get("metadata", {}).get("name")
-        bonfire_deps = item.get("metadata", {}).get("annotations", {}) \
-            .get("bonfire.dependencies", "").split(',')
-        filtered_bonfire_deps = list(filter(lambda x: x != '', bonfire_deps))
+        metadata = item.get("metadata", {})
+        name = metadata.get("name")
+        bonfire_deps = metadata.get("annotations", {}).get("bonfire.dependencies", "").split(',')
+        filtered_bonfire_deps = [dep for dep in bonfire_deps if dep]
         if name and filtered_bonfire_deps:
             deps_for_app[name].update(filtered_bonfire_deps)
 

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -371,7 +371,7 @@ class RepoFile:
             return commit, fp.read()
 
 
-def get_dependencies(items, optional=False):
+def get_clowdapp_dependencies(items, optional=False):
     """
     Returns dict of clowdapp_name: set of dependencies found for any ClowdApps in 'items'
 
@@ -390,15 +390,31 @@ def get_dependencies(items, optional=False):
         log.debug("clowdapp '%s' has %s: %s", name, key, list(dependencies))
         deps_for_app[name] = dependencies
 
+    return deps_for_app
+
+
+def get_dependencies(items):
+    """
+    Returns set of dependencies found when looking at 'bonfire.dependencies' annotation on resources
+    """
+    deps = set()
+
     for item in items:
+        kind = item.get("kind", "")
         metadata = item.get("metadata", {})
         name = metadata.get("name")
         bonfire_deps = metadata.get("annotations", {}).get("bonfire.dependencies", "").split(",")
         filtered_bonfire_deps = [dep for dep in bonfire_deps if dep]
         if name and filtered_bonfire_deps:
-            deps_for_app[name].update(filtered_bonfire_deps)
+            log.debug(
+                "resource %s/%s has bonfire.dependencies: %s",
+                kind.lower(),
+                name,
+                list(filtered_bonfire_deps),
+            )
+            deps.update(filtered_bonfire_deps)
 
-    return deps_for_app
+    return deps
 
 
 def find_what_depends_on(apps_config, clowdapp_name):
@@ -417,8 +433,8 @@ def find_what_depends_on(apps_config, clowdapp_name):
             template = yaml.safe_load(template_content)
             items = template.get("objects", [])
 
-            dependencies = get_dependencies(items)
-            optional_dependencies = get_dependencies(items, optional=True)
+            dependencies = get_clowdapp_dependencies(items)
+            optional_dependencies = get_clowdapp_dependencies(items, optional=True)
 
             all_dependencies = {}
             all_keys = dependencies.keys() | optional_dependencies.keys()

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -393,7 +393,7 @@ def get_dependencies(items, optional=False):
     for item in items:
         metadata = item.get("metadata", {})
         name = metadata.get("name")
-        bonfire_deps = metadata.get("annotations", {}).get("bonfire.dependencies", "").split(',')
+        bonfire_deps = metadata.get("annotations", {}).get("bonfire.dependencies", "").split(",")
         filtered_bonfire_deps = [dep for dep in bonfire_deps if dep]
         if name and filtered_bonfire_deps:
             deps_for_app[name].update(filtered_bonfire_deps)

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -393,7 +393,7 @@ def get_dependencies(items, optional=False):
     for item in items:
         name = item.get("metadata", {}).get("name")
         bonfire_deps = item.get("metadata", {}).get("annotations", {}) \
-        .get("bonfire.dependencies", "").split(',')
+            .get("bonfire.dependencies", "").split(',')
         filtered_bonfire_deps = list(filter(lambda x: x != '', bonfire_deps))
         if name and filtered_bonfire_deps:
             deps_for_app[name].update(filtered_bonfire_deps)

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -392,7 +392,8 @@ def get_dependencies(items, optional=False):
 
     for item in items:
         name = item.get("metadata", {}).get("name")
-        bonfire_deps = item.get("metadata", {}).get("annotations",{}).get("bonfire.dependencies","").split(',')
+        bonfire_deps = item.get("metadata", {}).get("annotations", {}) \
+        .get("bonfire.dependencies", "").split(',')
         filtered_bonfire_deps = list(filter(lambda x: x != '', bonfire_deps))
         if name and filtered_bonfire_deps:
             deps_for_app[name].update(filtered_bonfire_deps)


### PR DESCRIPTION
ticket: https://issues.redhat.com/browse/RHCLOUD-28382

This is adding logic for bonfire to gather dependencies listed under the annotation `bonfire.dependencies`. This supports the need for some apps to have dependencies that are not clowdapps.