### PR TITLE
Support --no-remove for app with --remove for component

### DIFF
--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -279,8 +279,6 @@ def _should_remove(
     if app_name in remove_option.apps:
         return True
 
-    # in theory all use cases should be covered by the above logic, throw an exception
-    # so we can identify if we missed a use case
     return default
 
 

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -245,7 +245,8 @@ def _should_remove(
     #   "--remove-option all" is set
     #   "--remove-option all --no-remove-option x" is set and app/component does NOT match 'x'
     #   "--no-remove-option all --remove-option x" is set and app/component matches 'x'
-    #   "--no-remove-option app1 --remove-option"
+    #   "--no-remove-option app1 --remove-option component" and component matches
+    #   none of the above conditions match and default=True
     remove_for_all_no_exceptions = remove_option.select_all and no_remove_option.empty
     remove_for_none_no_exceptions = no_remove_option.select_all and remove_option.empty
 

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -246,7 +246,7 @@ def _should_remove(
     #   "--remove-option all --no-remove-option x" is set and app/component does NOT match 'x'
     #   "--no-remove-option all --remove-option x" is set and app/component matches 'x'
     #   "--no-remove-option app1 --remove-option component" and component matches
-    #   none of the above conditions match and default=True
+    #   none of the setting permutations are matched and default=True
     remove_for_all_no_exceptions = remove_option.select_all and no_remove_option.empty
     remove_for_none_no_exceptions = no_remove_option.select_all and remove_option.empty
 

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -245,7 +245,8 @@ def _should_remove(
     #   "--remove-option all" is set
     #   "--remove-option all --no-remove-option x" is set and app/component does NOT match 'x'
     #   "--no-remove-option all --remove-option x" is set and app/component matches 'x'
-    #   "--no-remove-option app1 --remove-option component" and component matches
+    #   "--no-remove-option x --remove-option y" and app/component matches 'y'
+    #   "--remove-option x --no-remove-option y" and app/component matches 'x'
     #   none of the setting permutations are matched and default=True
     remove_for_all_no_exceptions = remove_option.select_all and no_remove_option.empty
     remove_for_none_no_exceptions = no_remove_option.select_all and remove_option.empty

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -558,3 +558,33 @@ def test_should_remove_component_overrides_app(default):
         _should_remove(remove_resources, no_remove_resources, "anything", "else", default)
         is default
     )
+
+
+@pytest.mark.parametrize("default", (True, False), ids=("default=True", "default=False"))
+def test_should_remove_component_app_combos(default):
+    # --no-remove-resources app:app2 --no-remove-resources component2 \
+    #   --remove-resources component1 --remove-resources app:app1
+    remove_resources = AppOrComponentSelector(
+        select_all=False, components=["component1"], apps=["app1"]
+    )
+    no_remove_resources = AppOrComponentSelector(
+        select_all=False, components=["component2"], apps=["app2"]
+    )
+
+    assert (
+        _should_remove(remove_resources, no_remove_resources, "app2", "component1", default) is True
+    )
+    assert (
+        _should_remove(remove_resources, no_remove_resources, "app1", "anything", default) is True
+    )
+    assert (
+        _should_remove(remove_resources, no_remove_resources, "app1", "component2", default)
+        is False
+    )
+    assert (
+        _should_remove(remove_resources, no_remove_resources, "app2", "anything", default) is False
+    )
+    assert (
+        _should_remove(remove_resources, no_remove_resources, "anything", "else", default)
+        is default
+    )

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -404,27 +404,27 @@ def test_mixed_deps_two_apps(mock_repo_file, processor, optional_deps_method, ex
 
 # Testing --no-remove-resources/dependency "app:" syntax
 def test_should_remove_remove_for_none_no_exceptions():
-    # --no-remove-resources all --no-remove-resources component1 --no-remove-resources app1
+    # --no-remove-resources all --no-remove-resources component1 --no-remove-resources app:app1
     remove_resources = AppOrComponentSelector(select_all=False, components=[], apps=[])
     no_remove_resources = AppOrComponentSelector(
         select_all=True, components=["component1"], apps=["app1"]
     )
 
-    assert _should_remove(remove_resources, no_remove_resources, "component2", "app2") is False
-    assert _should_remove(remove_resources, no_remove_resources, "component1", "app2") is False
-    assert _should_remove(remove_resources, no_remove_resources, "whatever", "app1") is False
+    assert _should_remove(remove_resources, no_remove_resources, "app2", "component2") is False
+    assert _should_remove(remove_resources, no_remove_resources, "app2", "component1") is False
+    assert _should_remove(remove_resources, no_remove_resources, "app1", "whatever") is False
 
 
 def test_should_remove_remove_for_all_no_exceptions():
-    # --remove-resources all --remove-resources component1 --remove-resources app1
+    # --remove-resources all --remove-resources component1 --remove-resources app:app1
     remove_resources = AppOrComponentSelector(
         select_all=True, components=["component1"], apps=["app1"]
     )
     no_remove_resources = AppOrComponentSelector(select_all=False, components=[], apps=[])
 
-    assert _should_remove(remove_resources, no_remove_resources, "component2", "app2") is True
-    assert _should_remove(remove_resources, no_remove_resources, "component1", "app2") is True
-    assert _should_remove(remove_resources, no_remove_resources, "whatever", "app1") is True
+    assert _should_remove(remove_resources, no_remove_resources, "app2", "component2") is True
+    assert _should_remove(remove_resources, no_remove_resources, "app2", "component1") is True
+    assert _should_remove(remove_resources, no_remove_resources, "app1", "whatever") is True
 
 
 def test_should_remove_remove_option_select_all():
@@ -538,4 +538,23 @@ def test_should_remove_no_remove_option_select_all():
             "component1",
         )
         is False
+    )
+
+
+@pytest.mark.parametrize("default", (True, False), ids=("default=True", "default=False"))
+def test_should_remove_component_overrides_app(default):
+    # --no-remove-resources app:app1 --remove-resources component1
+    remove_resources = AppOrComponentSelector(select_all=False, components=["component2"], apps=[])
+    no_remove_resources = AppOrComponentSelector(select_all=False, components=[], apps=["app1"])
+
+    assert (
+        _should_remove(remove_resources, no_remove_resources, "app1", "component1", default)
+        is False
+    )
+    assert (
+        _should_remove(remove_resources, no_remove_resources, "app1", "component2", default) is True
+    )
+    assert (
+        _should_remove(remove_resources, no_remove_resources, "anything", "else", default)
+        is default
     )


### PR DESCRIPTION
Allows scenarios like this to work:
```
--no-remove-resources app:app1 --remove-resources component1
```

Where you want to do 'no-remove-resources' for app1 EXCEPT for component1, which you do want to remove resources on.