### PR TITLE
None is not respected for namespace as clowd_env gets in the way

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -1059,7 +1059,10 @@ def _cmd_process(
     preferred_params,
 ):
     """Fetch and process application templates"""
-    clowd_env = _get_env_name(namespace, clowd_env)
+    if namespace is None:
+        clowd_env = None
+    else:
+        clowd_env = _get_env_name(namespace, clowd_env)
 
     processed_templates = _process(
         app_names,


### PR DESCRIPTION
Currently when you don't specfiy namespace for `process` you get an error that you need to supply one. This is incorrect, as you could simply say the namespace is `foo` or even `None` and it will proceed correctly.

Just skipping `_get_env_name` since there is no environment fixes the issue.