### PR TITLE
Add env vars to specify trusted apps/components

### DIFF
--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -66,6 +66,16 @@ BONFIRE_DEFAULT_FALLBACK_REF_ENV = str(
     os.getenv("BONFIRE_DEFAULT_FALLBACK_REF_ENV", "insights-stage")
 )
 
+# list of apps we will not remove resource requests/limits for
+TRUSTED_APPS = ["host-inventory"]
+if os.getenv("BONFIRE_TRUSTED_APPS"):
+    TRUSTED_APPS = os.getenv("BONFIRE_TRUSTED_APPS").split(",")
+
+# list of components we will not remove requests/limits for
+TRUSTED_COMPONENTS = []
+if os.getenv("BONFIRE_TRUSTED_COMPONENTS"):
+    TRUSTED_COMPONENTS = os.getenv("BONFIRE_TRUSTED_COMPONENTS").split(",")
+
 ELASTICSEARCH_HOST = os.getenv("ELASTICSEARCH_HOST", DEFAULT_ELASTICSEARCH_HOST)
 ELASTICSEARCH_APIKEY = os.getenv("ELASTICSEARCH_APIKEY")
 ENABLE_TELEMETRY = os.getenv("ENABLE_TELEMETRY", DEFAULT_ENABLE_TELEMETRY).lower() == "true"

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -248,6 +248,11 @@ def _should_remove(
     #   "--no-remove-option x --remove-option y" and app/component matches 'y'
     #   "--remove-option x --no-remove-option y" and app/component matches 'x'
     #   none of the setting permutations are matched and default=True
+
+    if app_name in conf.TRUSTED_APPS or component_name in conf.TRUSTED_COMPONENTS:
+        # if app/component is trusted, do not remove its resources
+        return False
+
     remove_for_all_no_exceptions = remove_option.select_all and no_remove_option.empty
     remove_for_none_no_exceptions = no_remove_option.select_all and remove_option.empty
 

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -593,7 +593,7 @@ class TemplateProcessor:
         if app_name in conf.TRUSTED_APPS:
             log.debug("should_remove: app '%s' listed in trusted apps", app_name)
         elif component_name in conf.TRUSTED_COMPONENTS:
-            log.debug("should_remove: component '%s' listed in trusted apps", component_name)
+            log.debug("should_remove: component '%s' listed in trusted components", component_name)
         else:
             should_remove_resources = _should_remove(
                 self.remove_resources,


### PR DESCRIPTION
If an app or component is found in these lists, then we will not strip the resource configs off of its template during processing.

Using a hard-coded list like this is a work-around until we fully develop the way to "intelligently trust" app resource configurations.

The host-inventory app has been audited and resource configs will be adjusted via https://github.com/RedHatInsights/insights-host-inventory/pull/1595