### PR TITLE
Improved get_env_name logic, allows running `process` cmd without `--namespace` nor `--clowd-env`

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -601,8 +601,9 @@ _clowdenv_process_options = [
     click.option(
         "--namespace",
         "-n",
-        help="Target namespace of the ClowdEnvironment (default: none)",
+        help="Target namespace of the ClowdEnvironment",
         type=str,
+        required=True,
     ),
     click.option(
         "--quay-user",
@@ -613,9 +614,7 @@ _clowdenv_process_options = [
     click.option(
         "--clowd-env",
         "-e",
-        help=(
-            "Name of ClowdEnvironment (default: if --namespace provided, will try to find match)"
-        ),
+        help=("Name of ClowdEnvironment (default: env-<namespace>)"),
         type=str,
         default=None,
     ),
@@ -1363,9 +1362,10 @@ def _cmd_config_deploy(
         click.echo(ns)
 
 
-def _process_clowdenv(target_namespace, quay_user, env_name, template_file, local):
-    env_name = _get_env_name(target_namespace, env_name)
-    return process_clowd_env(target_namespace, quay_user, env_name, template_file, local)
+def _process_clowdenv(namespace, quay_user, clowd_env, template_file, local):
+    if not clowd_env:
+        clowd_env = f"env-{namespace}"
+    return process_clowd_env(namespace, quay_user, clowd_env, template_file, local)
 
 
 @main.command("process-env")

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -960,8 +960,8 @@ def _get_env_name(ns, env_name):
             log.info("searching for ClowdEnvironment tied to ns '%s'...", ns)
             match = find_clowd_env_for_ns(ns)
             if not match:
-                _error(
-                    f"could not find a ClowdEnvironment with target ns '{ns}'.  "
+                log.warning(
+                    "could not find a ClowdEnvironment with target ns '%s'.  "
                     "Specify one with '--clowd-env' if needed."
                 )
             else:

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -954,23 +954,30 @@ def _get_apps_config(
     return apps_config
 
 
-def _get_env_name(ns, env_name):
-    if not env_name:
-        if ns:
-            log.info("searching for ClowdEnvironment tied to ns '%s'...", ns)
-            match = find_clowd_env_for_ns(ns)
-            if not match:
-                log.warning(
-                    "could not find a ClowdEnvironment with target ns '%s'.  "
-                    "Specify one with '--clowd-env' if needed."
-                )
-            else:
-                env_name = match["metadata"]["name"]
-        else:
-            log.warning("neither '--clowd-env' nor '--namespace' provided")
-
+def _log_and_return(env_name):
     log.info("templates will be processed with parameter ENV_NAME='%s'", env_name)
     return env_name
+
+
+def _get_env_name(ns=None, env_name=None):
+    if env_name:
+        return _log_and_return(env_name)
+
+    if not ns:
+        log.warning("neither '--clowd-env' nor '--namespace' provided")
+        return _log_and_return(None)
+
+    log.info("searching for ClowdEnvironment tied to ns '%s'...", ns)
+    match = find_clowd_env_for_ns(ns)
+    if not match:
+        log.warning(
+            "could not find a ClowdEnvironment with target ns '%s'.  "
+            "Specify one with '--clowd-env' if needed.",
+            ns,
+        )
+        return _log_and_return(None)
+
+    return _log_and_return(match["metadata"]["name"])
 
 
 def _process(

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -961,7 +961,10 @@ def _get_env_name(ns, env_name):
             log.info("searching for ClowdEnvironment tied to ns '%s'...", ns)
             match = find_clowd_env_for_ns(ns)
             if not match:
-                log.warning("could not find a ClowdEnvironment tied to ns '%s'", ns)
+                _error(
+                    f"could not find a ClowdEnvironment with target ns '{ns}'.  "
+                    "Specify one with '--clowd-env' if needed."
+                )
             else:
                 env_name = match["metadata"]["name"]
         else:
@@ -1287,11 +1290,6 @@ def _cmd_config_deploy(
         import_secrets_from_dir(secrets_dir)
 
     clowd_env = _get_env_name(ns, clowd_env)
-    if not clowd_env:
-        _error(
-            f"could not find a ClowdEnvironment tied to ns '{ns}'.  Specify which env "
-            "to use with '--clowd-env'"
-        )
 
     def _err_handler(err):
         try:

--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -53,7 +53,6 @@ BASE_NAMESPACE_PATH = os.getenv(
     "/services/insights/ephemeral/namespaces/ephemeral-base.yml",
 )
 EPHEMERAL_ENV_NAME = os.getenv("EPHEMERAL_ENV_NAME", "insights-ephemeral")
-ENV_NAME_FORMAT = os.getenv("ENV_NAME_FORMAT", "env-{namespace}")
 
 # can be used to set name of 'requester' on namespace reservations
 BONFIRE_NS_REQUESTER = os.getenv("BONFIRE_NS_REQUESTER")

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -187,6 +187,12 @@ def wait_for_db_resources(namespace, timeout=600):
 def find_clowd_env_for_ns(ns):
     try:
         clowd_envs = get_json("clowdenvironment")
+    except ValueError as err:
+        if "unknown resource type" in str(err).lower():
+            log.error("hit unknown resource type error, possibly not logged in to cluster?")
+            clowd_envs = {"items": []}
+        else:
+            raise
     except ErrorReturnCode as err:
         log.debug("hit error running 'oc get clowdenvironment': %s", err)
         clowd_envs = {"items": []}

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -85,21 +85,35 @@ def _resources_for_ns_wait():
 def _all_resources_ready(namespace, timeout, watcher):
     already_waited_on = set()
 
-    # wait on ClowdEnvironment, if there's one using this ns as its targetNamespace
+    # wait on ClowdEnvironments if any ClowdApps reference one
     start = time.time()
 
-    clowd_env = find_clowd_env_for_ns(namespace)
-    if clowd_env:
+    clowd_envs = []
+
+    clowdapps = get_json("clowdapp", namespace=namespace)
+    for clowdapp in clowdapps["items"]:
+        env_name = clowdapp["spec"]["envName"]
+        if env_name not in clowd_envs:
+            log.info(
+                "will wait on ClowdEnvironment '%s' found on ClowdApp .spec.envName",
+                env_name,
+            )
+            clowd_envs.append(env_name)
+
+    env_waiters = []
+    for clowd_env in clowd_envs:
         waiter = ResourceWaiter(
             namespace,
             "clowdenvironment",
-            clowd_env["metadata"]["name"],
+            clowd_env,
             watch_owned=True,
             watcher=watcher,
         )
-        if not waiter.wait_for_ready(timeout):
-            return False
+        env_waiters.append(waiter)
+    if not wait_for_ready_threaded(env_waiters, timeout):
+        return False
 
+    for waiter in env_waiters:
         for key in waiter.observed_resources:
             already_waited_on.add(key)
 
@@ -111,7 +125,6 @@ def _all_resources_ready(namespace, timeout, watcher):
     start = time.time()
 
     waiters = []
-    clowdapps = get_json("clowdapp", namespace=namespace)
     for clowdapp in clowdapps["items"]:
         waiter = ResourceWaiter(
             namespace, "clowdapp", clowdapp["metadata"]["name"], watch_owned=True, watcher=watcher

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -88,17 +88,17 @@ def _all_resources_ready(namespace, timeout, watcher):
     # wait on ClowdEnvironments if any ClowdApps reference one
     start = time.time()
 
-    clowd_envs = []
-
+    clowd_envs = set()
     clowdapps = get_json("clowdapp", namespace=namespace)
+
     for clowdapp in clowdapps["items"]:
         env_name = clowdapp["spec"]["envName"]
         if env_name not in clowd_envs:
             log.info(
-                "will wait on ClowdEnvironment '%s' found on ClowdApp .spec.envName",
+                "will wait on ClowdEnvironment '%s' found on ClowdApp's .spec.envName",
                 env_name,
             )
-            clowd_envs.append(env_name)
+            clowd_envs.add(env_name)
 
     env_waiters = []
     for clowd_env in clowd_envs:


### PR DESCRIPTION
Currently we check that a user either passed `--namespace` or `--clowd-env` when running the `process` command to prevent a user from processing templates with an invalid ClowdEnvironment name. This is because we always set the `ENV_NAME` parameter when we process templates (https://github.com/RedHatInsights/bonfire/blob/master/bonfire/processor.py#L577) due to the parameter being required on ClowdApp templates.

But this makes running 'process' for dry run/offline use a bit annoying since you have to always specify a fake argument for one of those options. And also, if you are not processing a template with ClowdApps, there is not much need to supply this argument.

The `deploy` command already has safeguards in it which check to make sure the ClowdEnvironment can be located. I think we can assume that if a user is using `process` without any args, they are doing it for a reason, and we can just log some informative warnings. Worst case scenario is they apply the config with the ENV_NAME set to `None`. In case they do, I have changed the way that `wait_for_all_resources` runs to catch the scenario where a ClowdApp exists but it has a bad ClowdEnvironment name set.

This PR changes the logic for `get_env_name`:
1. If `--clowd-env` is given, just use that.
2. If `--namespace` is given, try to find the ClowdEnvironment tied to it -- if we can't, log a warning, ENV_NAME will be `None`
3. If neither params are given, ENV_NAME will be `None`

And now the `_all_resources_ready` check now determines which ClowdEnvironments to wait on based on what it sees set in ClowdApps. For example if one is in the namespace with a value of `None`, the user now sees this:
```
2024-01-19 12:38:24 [    INFO] [          MainThread] will wait on ClowdEnvironment 'None' found on ClowdApp .spec.envName
2024-01-19 12:38:24 [    INFO] [thread-5 (wait_for_ready)] [clowdenvironment/none] waiting up to 600sec for resource to be 'ready'
```

Since get_env_name used to be shared by the `process-env` / `deploy-env` commands, to simplify things they will no longer use that function and simply require `-n` to specify the ClowdEnvironment target namespace. This is not a commonly used command and the only place in our docs (related to local setup on minikube) where we did mention it used `-n` already.