### PR TITLE
Add dockerfile for Bonfire

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN groupadd -r -g 1000 bonfire && \
 
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-$OC_CLI_VERSION/openshift-client-linux.tar.gz \
   -o oc.tar.gz && \
-  tar -C /usr/bin/ -xvzf oc.tar.gz oc && \
+  tar -C /usr/bin/ -xvzf oc.tar.gz oc kubectl && \
   rm -f oc.tar.gz
 
 USER bonfire
@@ -20,5 +20,6 @@ ENV PATH="/opt/bonfire/.venv/bin:$PATH"
 
 RUN pip install crc-bonfire
 RUN bonfire config write-default
+COPY entrypoint.sh .
 
-CMD ["bonfire"]
+ENTRYPOINT ["/opt/bonfire/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1107
+
+ARG OC_CLI_VERSION=4.12
+
+RUN microdnf install python3 shadow-utils tar gzip
+
+RUN groupadd -r -g 1000 bonfire && \
+    useradd -r -u 1000 -g bonfire -m -d /opt/bonfire -s /bin/bash bonfire
+
+RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-$OC_CLI_VERSION/openshift-client-linux.tar.gz \
+  -o oc.tar.gz && \
+  tar -C /usr/bin/ -xvzf oc.tar.gz oc && \
+  rm -f oc.tar.gz
+
+USER bonfire
+WORKDIR /opt/bonfire
+
+RUN python3 -m venv .venv
+ENV PATH="/opt/bonfire/.venv/bin:$PATH"
+
+RUN pip install crc-bonfire
+RUN bonfire config write-default
+
+CMD ["bonfire"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,9 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-$OC
 
 USER bonfire
 WORKDIR /opt/bonfire
+ENV PATH="/opt/bonfire/.local/bin:$PATH"
 
-RUN python3 -m venv .venv
-ENV PATH="/opt/bonfire/.venv/bin:$PATH"
-
-RUN pip install crc-bonfire
+RUN pip3 install crc-bonfire --user
 RUN bonfire config write-default
 COPY entrypoint.sh .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1107
 
-ARG OC_CLI_VERSION=4.12
+ARG OC_CLI_VERSION=4.14
 
-RUN microdnf install python3 shadow-utils tar gzip
+RUN microdnf install python3 shadow-utils tar gzip && \
+    microdnf clean all
 
 RUN groupadd -r -g 1000 bonfire && \
     useradd -r -u 1000 -g bonfire -m -d /opt/bonfire -s /bin/bash bonfire

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ podman run -it --rm -e OC_LOGIN_SERVER=https://api.openshift.example.com:6443 \
 It can also make use of a Kube config file by mounting it on the container's HOME:
 
 ```
-podman run -it --rm -v $HOME/.kube/config:/opt/bonfire/.kube/config:Z,U \
+podman run -it --rm -v ${KUBECONFIG:="$HOME/.kube/config"}:/opt/bonfire/.kube/config:Z,U \
     quay.io/cloudservices/bonfire namespace list
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ echo 'GITHUB_TOKEN=<your api token>' >> ~/.config/bonfire/env
 
 **Please note**: When using the Github token (classic), it **must have** the `read:project` scope for the template fetching to work!
 
-## Using Docker
+## Using a container image (podman/docker)
 
-We provide a Docker image at quay.io/cloudservices/bonfire. The image wraps a Python virtual environment with **crc-bonfire** installed on it.
+We provide a container image at quay.io/cloudservices/bonfire. The image wraps a Python virtual environment with **crc-bonfire** installed on it.
 
-In order to use Bonfire you have to provide either a valid KUBE_CONFIG or a URL and a TOKEN to connect to the target Openshift cluster.
+In order to use Bonfire you have to provide either a valid KUBECONFIG or a URL and a TOKEN to connect to the target OpenShift cluster.
 
-The container's entrypoint already invokes the **bonfire** CLI with the arguments passed to the container, so you should be able to run any bonfire command you'd typically run by using:
+The container's entrypoint already invokes the **bonfire** CLI with the arguments passed to the container, so you should be able to run any bonfire command you'd typically run, for example:
 
 ```
 podman run -it --rm quay.io/cloudservices/bonfire version
@@ -89,17 +89,17 @@ podman run -it --rm -e OC_LOGIN_SERVER=https://api.openshift.example.com:6443 \
     quay.io/cloudservices/bonfire namespace list
 ```
 
-It can also make use of a Kube config file by mounting it on the container's HOME:
+You can also make use of the kubeconfig file on your host by mounting it into the container's `$HOME` directory:
 
 ```
-podman run -it --rm -v ${KUBECONFIG:="$HOME/.kube/config"}:/opt/bonfire/.kube/config:Z,U \
+podman run -it --rm --userns=keep-id:uid=1000,gid=1000 -v ${KUBECONFIG:="$HOME/.kube/config"}:/opt/bonfire/.kube/config:Z \
     quay.io/cloudservices/bonfire namespace list
 ```
 
-Although you can define the KUBECONFIG location using a variable:
+If you desire for the kubeconfig to live in a non-standard location in the container, you can mount the kubeconfig into another path in the container, and set the KUBECONFIG environment variable:
 
 ```
-podman run -it --rm -v $HOME/.kube/config:/opt/kubeconfig:Z,U \
+podman run -it --rm --userns=keep-id:uid=1000,gid=1000 -v $HOME/.kube/config:/opt/kubeconfig:Z \
     -e KUBECONFIG=/opt/kubeconfig \
     quay.io/cloudservices/bonfire namespace list
 ```

--- a/README.md
+++ b/README.md
@@ -76,15 +76,32 @@ In order to use Bonfire you have to provide either a valid KUBE_CONFIG or a URL 
 The container's entrypoint already invokes the **bonfire** CLI with the arguments passed to the container, so you should be able to run any bonfire command you'd typically run by using:
 
 ```
-podman run -it --rm quay.io/cloudservices/bonfire --version
+podman run -it --rm quay.io/cloudservices/bonfire version
 ```
 
 ### Using credentials
 
-The Bonfire image expects the OC_LOGIN_SERVER and OC_LOGIN_TOKEN variables to be defined in order to connect to an Openshift cluster.
+The Bonfire image can use the `OC_LOGIN_SERVER` and `OC_LOGIN_TOKEN` variables to connect to an Openshift cluster.
 
 ```
+podman run -it --rm -e OC_LOGIN_SERVER=https://api.openshift.example.com:6443 \
+    -e OC_LOGIN_TOKEN=some-api-token \
+    quay.io/cloudservices/bonfire namespace list
+```
 
+It can also make use of a Kube config file by mounting it on the container's HOME:
+
+```
+podman run -it --rm -v $HOME/.kube/config:/opt/bonfire/.kube/config:Z,U \
+    quay.io/cloudservices/bonfire namespace list
+```
+
+Although you can define the KUBECONFIG location using a variable:
+
+```
+podman run -it --rm -v $HOME/.kube/config:/opt/kubeconfig:Z,U \
+    -e KUBECONFIG=/opt/kubeconfig \
+    quay.io/cloudservices/bonfire namespace list
 ```
 
 # Quick Start

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ A wide range of CLI options allow you to customize exactly what combination of c
 
 # Installation
 
+## Installing locally
+
 We'd recommend setting up a virtual environment for bonfire:
 
 ```bash
@@ -64,6 +66,26 @@ echo 'GITHUB_TOKEN=<your api token>' >> ~/.config/bonfire/env
 ```
 
 **Please note**: When using the Github token (classic), it **must have** the `read:project` scope for the template fetching to work!
+
+## Using Docker
+
+We provide a Docker image at quay.io/cloudservices/bonfire. The image wraps a Python virtual environment with **crc-bonfire** installed on it.
+
+In order to use Bonfire you have to provide either a valid KUBE_CONFIG or a URL and a TOKEN to connect to the target Openshift cluster.
+
+The container's entrypoint already invokes the **bonfire** CLI with the arguments passed to the container, so you should be able to run any bonfire command you'd typically run by using:
+
+```
+podman run -it --rm quay.io/cloudservices/bonfire --version
+```
+
+### Using credentials
+
+The Bonfire image expects the OC_LOGIN_SERVER and OC_LOGIN_TOKEN variables to be defined in order to connect to an Openshift cluster.
+
+```
+
+```
 
 # Quick Start
 

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -exv
+
+CICD_TOOLS_URL="https://raw.githubusercontent.com/RedHatInsights/cicd-tools/main/src/bootstrap.sh"
+# shellcheck source=/dev/null
+source <(curl -sSL "$CICD_TOOLS_URL") image_builder
+
+export CICD_IMAGE_BUILDER_IMAGE_NAME='quay.io/cloudservices/bonfire'
+export CICD_IMAGE_BUILDER_BUILD_ARGS=("OC_CLI_VERSION=4.14")
+export CICD_IMAGE_BUILDER_ADDITIONAL_TAGS=("latest")
+
+cicd::image_builder::build_and_push

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,14 +6,11 @@ init_check() {
         return 0
     fi
 
-    if [ -z "$OC_LOGIN_SERVER" ]; then
-        echo "OC_LOGIN_SERVER environment variable not found"
-        return 1
-    fi
-
-    if [ -z "$OC_LOGIN_TOKEN" ]; then
-        echo "OC_LOGIN_TOKEN environment variable not found"
-        return 1
+    if openshift_credentials_present; then
+        if ! try_login_openshift; then
+            echo "Failed logging into Openshift!"
+            return 1
+        fi
     fi
 }
 
@@ -21,10 +18,16 @@ check_kube_config() {
     [[ -r "${HOME}/.kube/config" ]] || [[ -r "$KUBECONFIG" ]]
 }
 
+openshift_credentials_present() {
+    [[ -n "$OC_LOGIN_SERVER" ]] && [[ -n "$OC_LOGIN_TOKEN" ]]
+}
+
+try_login_openshift() {
+    oc login --server="$OC_LOGIN_SERVER" --token="$OC_LOGIN_TOKEN" 
+}
+
 if ! init_check; then
     exit 1
 fi
-
-oc login --server="$OC_LOGIN_SERVER" --token="$OC_LOGIN_TOKEN" 
 
 bonfire "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ init_check() {
 
     if openshift_credentials_present; then
         if ! try_login_openshift; then
-            echo "Failed logging into Openshift!"
+            echo "Failed to log into OpenShift!"
             return 1
         fi
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+init_check() {
+
+    if check_kube_config; then
+        return 0
+    fi
+
+    if [ -z "$OC_LOGIN_SERVER" ]; then
+        echo "OC_LOGIN_SERVER environment variable not found"
+        return 1
+    fi
+
+    if [ -z "$OC_LOGIN_TOKEN" ]; then
+        echo "OC_LOGIN_TOKEN environment variable not found"
+        return 1
+    fi
+}
+
+check_kube_config() {
+    [[ -r "${HOME}/.kube/config" ]] || [[ -r "$KUBECONFIG" ]]
+}
+
+if ! init_check; then
+    exit 1
+fi
+
+oc login --server="$OC_LOGIN_SERVER" --token="$OC_LOGIN_TOKEN" 
+
+bonfire "$@"


### PR DESCRIPTION
This adds support to build a Docker image of Bonfire with support for Openshift credentials via environment variables or Kube config files.