### PR TITLE
added json output option for namespace describe

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -904,12 +904,23 @@ def _cmd_namespace_wait_on_resources(namespace, timeout, db_only):
 
 @namespace.command("describe")
 @click.argument("namespace", required=False, type=str)
-def _describe_namespace(namespace):
+@click.option(
+        "--output",
+        "-o",
+        default="cli",
+        help="which output format to return the data in",
+        type=click.Choice(["cli", "json"], case_sensitive=False),
+)
+def _describe_namespace(namespace, output):
     """Get current namespace info"""
     if not namespace:
         namespace = current_namespace_or_error()
-
-    click.echo(describe_namespace(namespace))
+    if output == "json":
+        data = {}
+        data = describe_namespace(namespace, output)
+        click.echo(json.dumps(data, indent=2))
+    else:
+        click.echo(describe_namespace(namespace, output))
 
 
 def _get_apps_config(

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -915,12 +915,8 @@ def _describe_namespace(namespace, output):
     """Get current namespace info"""
     if not namespace:
         namespace = current_namespace_or_error()
-    if output == "json":
-        data = {}
-        data = describe_namespace(namespace, output)
-        click.echo(json.dumps(data, indent=2))
-    else:
-        click.echo(describe_namespace(namespace, output))
+
+    click.echo(describe_namespace(namespace, output))
 
 
 def _get_apps_config(

--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -1,4 +1,5 @@
 import copy
+import json
 import datetime
 import logging
 import base64
@@ -407,8 +408,10 @@ def describe_namespace(project_name: str, output: str):
                 "clowdapps_deployed": num_clowdapps,
                 "frontends_deployed": num_frontends,
                 "default_username": kc_creds['defaultUsername'],
-                "defualt_password": kc_creds['defaultPassword'],
+                "default_password": kc_creds['defaultPassword'],
+                "gateway_route": f"https://{fe_host}",
             }
+        data = json.dumps(data, indent=2)
 
     return data
 

--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -373,7 +373,7 @@ def extend_namespace(namespace, duration, local=True):
     log.info("reservation for ns '%s' extended by '%s'", namespace, duration)
 
 
-def describe_namespace(project_name: str):
+def describe_namespace(project_name: str, output: str):
     ns_data = get_json("namespace", project_name)
     if not ns_data:
         raise FatalError(f"namespace '{project_name}' not found")
@@ -389,17 +389,27 @@ def describe_namespace(project_name: str):
     kc_creds = get_keycloak_creds(project_name)
     project_url = get_console_url()
 
-    output = f"\nCurrent project: {project_name}\n"
+    data = f"\nCurrent project: {project_name}\n"
     if project_url:
         ns_url = f"{project_url}/k8s/cluster/projects/{project_name}"
-        output += f"Project URL: {ns_url}\n"
-    output += f"Keycloak admin route: {keycloak_url}\n"
-    output += f"Keycloak admin login: {kc_creds['username']} | {kc_creds['password']}\n"
-    output += f"{num_clowdapps} ClowdApp(s), " f"{num_frontends} Frontend(s) deployed\n"
-    output += f"Gateway route: https://{fe_host}\n"
-    output += f"Default user login: {kc_creds['defaultUsername']} | {kc_creds['defaultPassword']}\n"
+        data += f"Project URL: {ns_url}\n"
+    data += f"Keycloak admin route: {keycloak_url}\n"
+    data += f"Keycloak admin login: {kc_creds['username']} | {kc_creds['password']}\n"
+    data += f"{num_clowdapps} ClowdApp(s), " f"{num_frontends} Frontend(s) deployed\n"
+    data += f"Gateway route: https://{fe_host}\n"
+    data += f"Default user login: {kc_creds['defaultUsername']} | {kc_creds['defaultPassword']}\n"
+    if output == "json":
+        data = {
+                "namespace": project_name,
+                "keycloak_admin_route": keycloak_url,
+                "keycloak_admin_username": kc_creds['username'],
+                "keycloak_admin_password": kc_creds['password'],
+                "clowdapps_frontends_deployed": num_frontends,
+                "default_username": kc_creds['defaultUsername'],
+                "defualt_password": kc_creds['defaultPassword'],
+            }
 
-    return output
+    return data
 
 
 def parse_fe_env(project_name):

--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -404,7 +404,8 @@ def describe_namespace(project_name: str, output: str):
                 "keycloak_admin_route": keycloak_url,
                 "keycloak_admin_username": kc_creds['username'],
                 "keycloak_admin_password": kc_creds['password'],
-                "clowdapps_frontends_deployed": num_frontends,
+                "clowdapps_deployed": num_clowdapps,
+                "frontends_deployed": num_frontends,
                 "default_username": kc_creds['defaultUsername'],
                 "defualt_password": kc_creds['defaultPassword'],
             }


### PR DESCRIPTION
Adding json output option for `bonfire namespace describe`


`bonfire namespace describe -o json`

Output:
```
{
  "namespace": "<value>",
  "keycloak_admin_route": "<value>",
  "keycloak_admin_username": "<value>",
  "keycloak_admin_password": "<value>",
  "clowdapps_frontends_deployed":<value>
  "default_username": "<value>",
  "defualt_password": "<value>"
}
```