### PR TITLE
feat(ci): use pre-commit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,8 @@ jobs:
         python-version: '3.10'
         architecture: 'x64'
 
+    - uses: pre-commit/action@v3.0.1
+
     - name: Install build dependencies
       run: |
         python -m pip install -U pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.4.6
+  hooks:
+    # Run the linter.
+    - id: ruff
+      args: [ --fix ]
+    # Run the formatter.
+    - id: ruff-format
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,4 @@ Homepage = "https://www.github.com/RedHatInsights/bonfire"
 [tool.ruff]
 line-length = 100
 indent-width = 4
+


### PR DESCRIPTION
Adds a `pre-commit` config file and uses a Github action to run pre-commit with `ruff` to lint and format the code. 

Behavior changes:
 - `ruff` is now used instead of `flake8`
 - The pipeline will now FAIL if the linter fails, or if the formatter finds some formatting that needs to be applied.