### PR TITLE
Refactor release to support trusted publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,41 +1,73 @@
 name: Publish crc-bonfire to PyPI
 
-on:
-  push:
-    branches:
-      - master
-    tags:
-      - '*'
+on: push
 
 jobs:
-  build-and-publish:
-    name: Build and publish to PyPI
-    if: startsWith(github.event.ref, 'refs/tags')
-    runs-on: ubuntu-20.04
+  build:
+    name: Build 📦
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout to master
-        uses: actions/checkout@v3
-
-      - name: Setup python
-        uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
-          architecture: 'x64'
-
+          python-version: "3.x"
       - name: Install build dependencies
         run: |
-          python -m pip install -U pip
-          pip install -U wheel setuptools build twine
-
+          pip install build twine
       - name: Build sdist and wheel
         run: |
-          python -m build -o dist/
-      
+          python -m build
       - name: Twine check
         run: python -m twine check dist/*
-
-      - name: Deploy to PyPi
-        uses: pypa/gh-action-pypi-publish@master
+      - name: Store artifacts
+        uses: actions/upload-artifact@v3
         with:
-          user: __token__
-          password: ${{ secrets.pypi_token }}
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-testpypi:
+    name: Publish to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/crc-bonfire
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/          
+
+  publish:
+    name: Build and publish to PyPI
+    if: startsWith(github.event.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    environment:
+      name: release
+      url: https://pypi.org/p/crc-bonfire
+    permissions:
+      # mandatory for trusted publishing
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
- Split build and release jobs
- Add test-release job to Test.Pypi
- Refactor release to use trusted publishers (OIDC) with PyPi