### PR TITLE
Fix log message when handling RequestException

### DIFF
--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -552,8 +552,8 @@ def check_pypi():
         response = requests.get(PYPI_URL, timeout=5)
         response.raise_for_status()
         pkg_data = response.json()
-    except requests.exceptions.RequestException as e:
-        log.error("error fetching version from pypi: ", e.errno, e.message)
+    except requests.exceptions.RequestException as err:
+        log.error("error fetching version from pypi: %s", err)
     except ValueError:
         log.error("response was not valid json")
 


### PR DESCRIPTION
Fixes:

```
  File "/iqe_venv/lib64/python3.11/site-packages/bonfire/utils.py", line 556, in check_pypi
    log.error("error fetching version from pypi: ", e.errno, e.message)
                                                             ^^^^^^^^^
AttributeError: 'ConnectionError' object has no attribute 'message'
```