### PR TITLE
(feat): Preserve trusted cpu/mem resource configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,11 @@ Once you have audited your container CPU/mem usage in test environments and have
 If these steps are followed then your resource config is considered "trusted" and bonfire will not remove the requests/limits configurations.
 
 
+**NOTE:** a couple things that will change in the future:
+* The "host-inventory" app is trusted by default, but once their configurations are tweaked to be trusted we will remove this
+* Object types such as Deployment/StatefulSet/DaemonSet/etc. are not currently analyzed. In future once teams have audited all container resource configurations, we will begin to have bonfire check for trusted configurations on all object types.
+
+
 # Interactions with Ephemeral Namespace Operator
 
 `bonfire` creates/modifies `NamespaceReservation` resources on the cluster to reserve and release namespaces. The template for the object that bonfire applies into the cluster can be found [here](bonfire/resources/reservation-template.yaml)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ As an example, typing `bonfire deploy host-inventory` leads to the host-inventor
 - [Examples for Common Use Cases](#examples-for-common-use-cases)
 - [Commonly Used CLI Options](#commonly-used-cli-options)
   - [Deploying/Processing](#deployingprocessing)
+  - [Trusted/Untrusted Resource Configurations](#trusteduntrusted-resource-configurations)
 - [Interactions with Ephemeral Namespace Operator](#interactions-with-ephemeral-namespace-operator)
 - [Interactions with Clowder Operator](#interactions-with-clowder-operator)
   - [ClowdEnvironments](#clowdenvironments)
@@ -120,7 +121,7 @@ Once logged in, you should be able to type `bonfire deploy advisor`
 
 This will cause `bonfire` to do the following:
 1. reserve a namespace
-2. fetch the templates for all components in the 'advisor' app and process them. By default, bonfire will look up the template and commit hash using the 'main'/'master' branch of each component defined in the app. It will look up the git commit hash for this branch and automatically set the `IMAGE_TAG` parameter passed to the templates. 
+2. fetch the templates for all components in the 'advisor' app and process them. By default, bonfire will look up the template and commit hash using the 'main'/'master' branch of each component defined in the app. It will look up the git commit hash for this branch and automatically set the `IMAGE_TAG` parameter passed to the templates.
 3. if ClowdApp resources are found, figure out which additional ClowdApps to fetch and process
 4. apply all the processed template resources into your reserved namespace
 5. wait for all the resources to reach a 'ready' state
@@ -210,6 +211,26 @@ bonfire deploy advisor --set-image-tag quay.io/cloudservices/advisor-backend=my_
 * `--optional-deps-method <hybrid|all|none>` -- change the way that bonfire processes ClowdApp optional dependencies (see "Dependency Processing" section)
 * `--prefer PARAM_NAME=PARAM_VALUE` -- in cases where bonfire finds more than one deployment target, use this to set the parameter names and values that should be used to select a "preferred" deployment target. This option can be passed in multiple times. `bonfire` will select the target with the highest amount of "preferred parameters" on it. Default is currently set to `ENV_NAME=frontends` to select "stable" frontends in the consoledot environments.
 
+## Trusted/Untrusted Resource Configurations
+
+When templates are processed, bonfire removes all untrusted CPU/Memory requests and limits from ClowdApp/ClowdJob/ClowdJobInvocation objects within OpenShift templates (this is because the default value for `--remove-resources` is `all`). If the resource config is unset in a ClowdApp, Clowder will set the deployments to use default values defined in the “ClowdEnvironment” to take effect.
+
+ The reason for this behavior is because many app templates tend to request far more CPU/memory in their template compared to what they actually need in a test environment.
+
+You can use the `--no-remove-resources` option to turn this behavior off for certain apps or components but the preferred approach is to audit your CPU/memory configurations and set up a resource configuration that bonfire trusts.
+
+Once you have audited your container CPU/mem usage in test environments and have determined efficient values that you want to use, you can indicate that bonfire should trust the CPU/Memory requests and limits by adhering to the following requirements:
+
+1. Any ClowdApp/ClowdJob/ClowdJobInvocation in your template asking for CPU/mem using requests or limits should use a parameter with a name formatted like this:
+* `CPU_REQUEST_<NAME>`
+* `CPU_LIMIT_<NAME>`
+* `MEM_REQUEST_<NAME>`
+* `MEM_LIMIT_<NAME>`
+
+2. Your deployment configuration for the component must explicitly define values for these parameters. For ephemeral environments normally this will mean that your parameters are defined under the ephemeral deploy target in app-interface.
+
+If these steps are followed then your resource config is considered "trusted" and bonfire will not remove the requests/limits configurations.
+
 
 # Interactions with Ephemeral Namespace Operator
 
@@ -243,7 +264,7 @@ When bonfire processes templates, if it finds a ClowdApp, it will do the followi
     * You will end up with all components of `app-a`, `app-b-clowdapp`, AND `app-c-clowdapp` deployed into the namespace.
   * `none`: `bonfire` will ignore the `optionalDependencies` on all ClowdApps that it encounters
 
-# Configuration Details 
+# Configuration Details
 
 > NOTE: for information related to app-interface configurations, see the internal [ConsoleDot Docs](https://consoledot.pages.redhat.com/)
 
@@ -266,7 +287,7 @@ By default, if app components use `ClowdApp` resources in their templates, then 
 
 `bonfire` ships with a [default config](bonfire/resources/default_config.yaml) that should be enough to get started for most internal Red Hat employees.
 
-By default, the configuration file will be stored in `~/.config/bonfire/config.yaml`. 
+By default, the configuration file will be stored in `~/.config/bonfire/config.yaml`.
 
 If you wish to override any app configurations, you can edit your local configuration file by typing `bonfire config edit`. You can then define an app under the `apps` key of the config. You can reset the config to default at any time using `bonfire config write-default`.
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,10 @@ Once you have audited your container CPU/mem usage in test environments and have
 * `MEM_REQUEST_<NAME>`
 * `MEM_LIMIT_<NAME>`
 
+Where `<NAME>` can be whatever arbitrary name you'd like to use containing `A-Z`, `0-9,` and `_`. For example, either of these would be valid:
+* `CPU_REQUEST_MQ_CONSUMER`
+* `MEM_LIMIT_API`
+
 2. Your deployment configuration for the component must explicitly define values for these parameters. For ephemeral environments normally this will mean that your parameters are defined under the ephemeral deploy target in app-interface.
 
 If these steps are followed then your resource config is considered "trusted" and bonfire will not remove the requests/limits configurations.

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -545,9 +545,9 @@ _process_options = _app_source_options + [
     click.option(
         "--remove-resources",
         help=(
-            "Remove resource limits and requests on ClowdApp configs "
-            "for specific components or apps. Prefix the app name with "
-            "'app:', otherwise specify the component name. (default: all)"
+            "Remove untrusted (defined in README) resource limits/requests on "
+            "ClowdApp/ClowdJob/CJI objects for specific components or apps. Prefix the app name "
+            "with 'app:', otherwise specify the component name. (default: 'all')"
         ),
         type=str,
         multiple=True,
@@ -556,9 +556,9 @@ _process_options = _app_source_options + [
     click.option(
         "--no-remove-resources",
         help=(
-            "Don't remove resource limits and requests on ClowdApp configs "
-            "for specific components or apps. Prefix the app name with "
-            "'app:', otherwise specify the component name. (default: none)"
+            "Preserve resource limits/requests even if untrusted (defined in README) on "
+            "ClowdApp/ClowdJob/CJI objects for specific components or apps. Prefix the app name "
+            "with 'app:', otherwise specify the component name. (default: none)"
         ),
         type=str,
         multiple=True,

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -1416,9 +1416,9 @@ def _cmd_config_deploy(
             ns_url = f"{url}/k8s/cluster/projects/{ns}"
             log.info("namespace url: %s", ns_url)
             log.info(
-                "resource usage dashboard for namespace '%s': https://grafana.app-sre.devshift.net/d/jRY7KLnVz?var-namespace=%s",
+                "resource usage dashboard for namespace '%s': %s",
                 ns,
-                ns,
+                conf.RESOURCE_DASHBOARD_URL.format(namespace=ns),
             )
         click.echo(ns)
 

--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -89,14 +89,14 @@ if os.getenv("BONFIRE_TRUSTED_COMPONENTS"):
     TRUSTED_COMPONENTS = os.getenv("BONFIRE_TRUSTED_COMPONENTS").split(",")
 
 # regexes used to check for trusted resource request/limit
-TRUSTED_PARAM_REGEX_FOR_PATH = {
+TRUSTED_REGEX_FOR_PATH = {
     "resources.requests.cpu": r"\${(CPU_REQUEST[A-Z0-9_]+)}",
     "resources.limits.cpu": r"\${(CPU_LIMIT[A-Z0-9_]+)}",
     "resources.requests.memory": r"\${(MEM_REQUEST[A-Z0-9_]+)}",
     "resources.limits.memory": r"\${(MEM_LIMIT[A-Z0-9_]+)}",
 }
 
-KINDS_FOR_RESOURCE_CHECK = ["ClowdApp", "ClowdJob", "ClowdJobInvocation"]
+TRUSTED_CHECK_KINDS = ["ClowdApp", "ClowdJob", "ClowdJobInvocation"]
 
 RESOURCE_DASHBOARD_URL = (
     "https://grafana.app-sre.devshift.net/d/jRY7KLnVz?var-namespace={namespace}"

--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -88,6 +88,14 @@ TRUSTED_COMPONENTS = []
 if os.getenv("BONFIRE_TRUSTED_COMPONENTS"):
     TRUSTED_COMPONENTS = os.getenv("BONFIRE_TRUSTED_COMPONENTS").split(",")
 
+# regexes used to check for trusted resource request/limit
+TRUSTED_PARAM_REGEX_FOR_PATH = {
+    "resources.requests.cpu": r"\${(CPU_REQUEST[A-Z0-9_]+)}",
+    "resources.limits.cpu": r"\${(CPU_LIMIT[A-Z0-9_]+)}",
+    "resources.requests.mem": r"\${(MEM_REQUEST[A-Z0-9_]+)}",
+    "resources.limits.mem": r"\${(MEM_LIMIT[A-Z0-9_]+)}",
+}
+
 ELASTICSEARCH_HOST = os.getenv("ELASTICSEARCH_HOST", DEFAULT_ELASTICSEARCH_HOST)
 ELASTICSEARCH_INDEX = os.getenv("ELASTICSEARCH_INDEX", DEFAULT_ELASTICSEARCH_INDEX)
 ELASTICSEARCH_APIKEY = os.getenv("ELASTICSEARCH_APIKEY")

--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -79,7 +79,7 @@ BONFIRE_DEFAULT_FALLBACK_REF_ENV = str(
 )
 
 # list of apps we will not remove resource requests/limits for
-TRUSTED_APPS = ["host-inventory"]
+TRUSTED_APPS = []
 if os.getenv("BONFIRE_TRUSTED_APPS"):
     TRUSTED_APPS = os.getenv("BONFIRE_TRUSTED_APPS").split(",")
 

--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -79,7 +79,7 @@ BONFIRE_DEFAULT_FALLBACK_REF_ENV = str(
 )
 
 # list of apps we will not remove resource requests/limits for
-TRUSTED_APPS = []
+TRUSTED_APPS = ["host-inventory"]
 if os.getenv("BONFIRE_TRUSTED_APPS"):
     TRUSTED_APPS = os.getenv("BONFIRE_TRUSTED_APPS").split(",")
 

--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -92,9 +92,15 @@ if os.getenv("BONFIRE_TRUSTED_COMPONENTS"):
 TRUSTED_PARAM_REGEX_FOR_PATH = {
     "resources.requests.cpu": r"\${(CPU_REQUEST[A-Z0-9_]+)}",
     "resources.limits.cpu": r"\${(CPU_LIMIT[A-Z0-9_]+)}",
-    "resources.requests.mem": r"\${(MEM_REQUEST[A-Z0-9_]+)}",
-    "resources.limits.mem": r"\${(MEM_LIMIT[A-Z0-9_]+)}",
+    "resources.requests.memory": r"\${(MEM_REQUEST[A-Z0-9_]+)}",
+    "resources.limits.memory": r"\${(MEM_LIMIT[A-Z0-9_]+)}",
 }
+
+KINDS_FOR_RESOURCE_CHECK = ["ClowdApp", "ClowdJob", "ClowdJobInvocation"]
+
+RESOURCE_DASHBOARD_URL = (
+    "https://grafana.app-sre.devshift.net/d/jRY7KLnVz?var-namespace={namespace}"
+)
 
 ELASTICSEARCH_HOST = os.getenv("ELASTICSEARCH_HOST", DEFAULT_ELASTICSEARCH_HOST)
 ELASTICSEARCH_INDEX = os.getenv("ELASTICSEARCH_INDEX", DEFAULT_ELASTICSEARCH_INDEX)

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -643,21 +643,21 @@ class TemplateProcessor:
         app_name = self._get_app_for_component(component_name)
 
         # if entire app or component is marked trusted, do not remove any resources
-        should_remove_untrusted_configs = False
+        should_remove_resources = False
         if app_name in conf.TRUSTED_APPS:
             log.debug("should_remove: app '%s' listed in trusted apps", app_name)
         elif component_name in conf.TRUSTED_COMPONENTS:
             log.debug("should_remove: component '%s' listed in trusted components", component_name)
         else:
-            should_remove_untrusted_configs = _should_remove(
+            should_remove_resources = _should_remove(
                 self.remove_resources,
                 self.no_remove_resources,
                 app_name,
                 component_name,
                 default=True,
             )
-        log.debug("should_remove_resources evaluates to %s", should_remove_untrusted_configs)
-        if should_remove_untrusted_configs:
+        log.debug("should_remove_resources evaluates to %s", should_remove_resources)
+        if should_remove_resources:
             _remove_untrusted_configs_for_template(template, params)
 
         # process the template

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -30,6 +30,19 @@ def _process_template(*args, **kwargs):
     return processed_template
 
 
+def _is_trusted_param(value, path, component_params):
+    trusted = False
+
+    for path_end, regex in conf.TRUSTED_PARAM_REGEX_FOR_PATH.items():
+        if path.endswith(path_end):
+            match = re.match(regex, value)
+            if match and match.groups()[0] in component_params:
+                trusted = True
+            log.debug("value '%s' at path '%s', trusted=%s", value, path, trusted)
+
+    return trusted
+
+
 def _label_trusted_resources(data, params, path=None):
     """
     Locate all instances of resource configurations within a template and label them as trusted
@@ -56,14 +69,9 @@ def _label_trusted_resources(data, params, path=None):
         for index, value in enumerate(data):
             _label_trusted_resources(value, params, path + f"[{index}]")
 
-    if path.endswith(".resources.limits.cpu"):
-        log.debug("found cpu limit config at %s: %s", path, data)
-    elif path.endswith(".resources.limits.memory"):
-        log.debug("found mem limit config at %s: %s", path, data)
-    elif path.endswith(".resources.requests.cpu"):
-        log.debug("found cpu request config at %s: %s", path, data)
-    elif path.endswith(".resources.requests.memory"):
-        log.debug("found mem limit config at %s: %s", path, data)
+    if _is_trusted_param(data, path, params):
+        # TODO: label it
+        pass
 
 
 def _remove_resource_config(items):


### PR DESCRIPTION
Consider the CPU/memory configuration of a template as “trusted” if:

* The config value is defined using a template parameter.
* The parameter name follows the naming convention:
```
CPU_REQUEST_<NAME>
CPU_LIMIT_<NAME>
MEM_REQUEST_<NAME>
MEM_LIMIT_<NAME>
```

(#402 adds support for either `MEM_` or `MEMORY_`)

* The parameter's value is explicitly set on the deploy configurations for the component in the target environment.

Currently we only analyze this on ClowdApp/ClowdJob/ClowdJobInvocation -- in future once all teams make the necessary changes we'd probably want to circle back and turn this "type check" off so all objects are analyzed.

Example log output when finding trusted and untrusted configs:
```
2024-07-02 12:59:08 [   DEBUG] [          MainThread] value '${CPU_LIMIT_SERVICE}', regex r'\${(CPU_LIMIT[A-Z0-9_]+)}', matches=True, in params=True
2024-07-02 12:59:08 [   DEBUG] [          MainThread] value '${MEMORY_LIMIT_SERVICE}', regex r'\${(MEM_LIMIT[A-Z0-9_]+)}', matches=False, in params=False
2024-07-02 12:59:08 [   DEBUG] [          MainThread] deleted untrusted config at '.spec.deployments[2].podSpec.resources.limits.memory'
2024-07-02 12:59:08 [   DEBUG] [          MainThread] value '${CPU_REQUEST_SERVICE}', regex r'\${(CPU_REQUEST[A-Z0-9_]+)}', matches=True, in params=True
2024-07-02 12:59:08 [   DEBUG] [          MainThread] value '${MEMORY_REQUEST_SERVICE}', regex r'\${(MEM_REQUEST[A-Z0-9_]+)}', matches=False, in params=False
2024-07-02 12:59:08 [   DEBUG] [          MainThread] deleted untrusted config at '.spec.deployments[2].podSpec.resources.requests.memory'
```