### PR TITLE
test on macos

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,12 +51,13 @@ jobs:
     - run: pipx run twine check --strict dist/*
 
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     needs: [build]
     strategy:
       matrix:
         # todo: extract from source
         python-version: [ 3.8, 3.9, '3.10', '3.11', '3.12' ]
+        os: [ubuntu-22.04, macos-latest]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         # todo: extract from source
-        python-version: [ 3.8, 3.9, '3.10', '3.11', '3.12' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
         os: [ubuntu-22.04, macos-latest]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,6 +68,10 @@ jobs:
       with:
         path: ${{ env.pythonLocation }}
         key: ${{ env.pythonLocation }}
+    - name: Install CLI tools from OpenShift Mirror
+      uses: redhat-actions/openshift-tools-installer@v1
+      with:
+        oc: "4"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
- Enables testing pipeline for MacOS nodes.
- Adds installer for `oc` - it was already present on Ubuntu runners, but not on MacOs ones.
- closes RHCLOUD-33785