### PR TITLE
feat: drop testing on Python 3.6 and 3.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   build-and-publish:
     name: Build and publish to PyPI
     if: startsWith(github.event.ref, 'refs/tags')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment:
       name: release
       url: https://pypi.org/p/crc-bonfire

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Checkout to master
@@ -37,7 +37,7 @@ jobs:
         path: dist
 
   build_check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [build]
     steps:
     - uses: actions/setup-python@v5
@@ -51,12 +51,12 @@ jobs:
     - run: pipx run twine check --strict dist/*
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [build]
     strategy:
       matrix:
         # todo: extract from source
-        python-version: [ 3.6, 3.7, 3.8, 3.9, '3.10', '3.11', '3.12' ]
+        python-version: [ 3.8, 3.9, '3.10', '3.11', '3.12' ]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
- Drop testing for unsupported Python versions
- Use ubuntu-latest for GHA runners