### PR TITLE
Tweak trusted memory parameter regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,12 +224,14 @@ Once you have audited your container CPU/mem usage in test environments and have
 1. Any ClowdApp/ClowdJob/ClowdJobInvocation in your template asking for CPU/mem using requests or limits should use a parameter with a name formatted like this:
 * `CPU_REQUEST_<NAME>`
 * `CPU_LIMIT_<NAME>`
-* `MEM_REQUEST_<NAME>`
-* `MEM_LIMIT_<NAME>`
+* `MEM_REQUEST_<NAME>` or `MEMORY_REQUEST_<NAME>`
+* `MEM_LIMIT_<NAME>` or `MEMORY_LIMIT_<NAME>`
 
-Where `<NAME>` can be whatever arbitrary name you'd like to use containing `A-Z`, `0-9,` and `_`. For example, either of these would be valid:
-* `CPU_REQUEST_MQ_CONSUMER`
-* `MEM_LIMIT_API`
+  Where `<NAME>` can be whatever arbitrary name you'd like to use containing `A-Z`, `0-9,` and `_`. For example, either of these would be valid:
+  * `CPU_REQUEST_MQ_CONSUMER`
+  * `MEM_LIMIT_API`
+
+  **NOTE:** If you only have a single component in your template, you can omit `_<NAME>` from the parameter names if you desire.
 
 2. Your deployment configuration for the component must explicitly define values for these parameters. For ephemeral environments normally this will mean that your parameters are defined under the ephemeral deploy target in app-interface.
 

--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -92,8 +92,8 @@ if os.getenv("BONFIRE_TRUSTED_COMPONENTS"):
 TRUSTED_REGEX_FOR_PATH = {
     "resources.requests.cpu": r"\${(CPU_REQUEST[A-Z0-9_]+)}",
     "resources.limits.cpu": r"\${(CPU_LIMIT[A-Z0-9_]+)}",
-    "resources.requests.memory": r"\${(MEM_REQUEST[A-Z0-9_]+)}",
-    "resources.limits.memory": r"\${(MEM_LIMIT[A-Z0-9_]+)}",
+    "resources.requests.memory": r"\${(MEM(?:ORY)?_REQUEST[A-Z0-9_]+)}",
+    "resources.limits.memory": r"\${(MEM(?:ORY)?_LIMIT[A-Z0-9_]+)}",
 }
 
 TRUSTED_CHECK_KINDS = ["ClowdApp", "ClowdJob", "ClowdJobInvocation"]

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -70,7 +70,7 @@ objects:
             memory: ${{MEM_LIMIT_DEPLOYMENT2}}
           requests:
             cpu: ${{DEPLOYMENT2_WRONG_NAME_CPU}}
-            memory: ${{MEM_REQUEST_DEPLOYMENT2}}
+            memory: ${{MEMORY_REQUEST_DEPLOYMENT2}}
 parameters:
 - description: Image tag
   name: IMAGE_TAG
@@ -88,7 +88,7 @@ parameters:
   value: 100Mi
 - name: DEPLOYMENT2_WRONG_NAME_CPU
   value: 2m
-- name: MEM_REQUEST_DEPLOYMENT2
+- name: MEMORY_REQUEST_DEPLOYMENT2
   value: 2Mi
 - name: MEM_LIMIT_DEPLOYMENT2
   value: 200Mi
@@ -681,7 +681,7 @@ def test_preserve_resources_trusted_params(mock_repo_file):
             "MEM_REQUEST_DEPLOYMENT1": "123Mi",
             "DEPLOYMENT2_WRONG_NAME_CPU": "1",
             "MEM_LIMIT_DEPLOYMENT2": "910Mi",
-            "MEM_REQUEST_DEPLOYMENT2": "789Mi",
+            "MEMORY_REQUEST_DEPLOYMENT2": "789Mi",
         }
     )
     processor = get_processor(apps_config)


### PR DESCRIPTION
Allow the param name to start with either `MEM` or `MEMORY`