### PR TITLE
Update --frontend command to include widget-layout

### DIFF
--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -123,6 +123,7 @@ DEFAULT_FRONTEND_DEPENDENCIES = (
     "host-inventory-frontend",
     "unleash-proxy",
     "service-accounts",
+    "widget-layout",
 )
 
 


### PR DESCRIPTION
This is a new dependency required by landing-page-frontend. Without this new dependency - the landing page will fail to load with the newly enabled `widgetization` unleash flags (which are currently enabled on stage/prod). 

The repo is here: https://github.com/RedHatInsights/widget-layout

The deploy config is here: https://github.com/RedHatInsights/widget-layout/blob/master/deploy/frontend.yaml

CC @wise-king-sullyman