### PR TITLE
fix: regex for trusted resource

### DIFF
--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -90,10 +90,10 @@ if os.getenv("BONFIRE_TRUSTED_COMPONENTS"):
 
 # regexes used to check for trusted resource request/limit
 TRUSTED_REGEX_FOR_PATH = {
-    "resources.requests.cpu": r"\${(CPU_REQUEST[A-Z0-9_]+)}",
-    "resources.limits.cpu": r"\${(CPU_LIMIT[A-Z0-9_]+)}",
-    "resources.requests.memory": r"\${(MEM(?:ORY)?_REQUEST[A-Z0-9_]+)}",
-    "resources.limits.memory": r"\${(MEM(?:ORY)?_LIMIT[A-Z0-9_]+)}",
+    "resources.requests.cpu": r"\${(CPU_REQUEST[A-Z0-9_]*)}",
+    "resources.limits.cpu": r"\${(CPU_LIMIT[A-Z0-9_]*)}",
+    "resources.requests.memory": r"\${(MEM(?:ORY)?_REQUEST[A-Z0-9_]*)}",
+    "resources.limits.memory": r"\${(MEM(?:ORY)?_LIMIT[A-Z0-9_]*)}",
 }
 
 TRUSTED_CHECK_KINDS = ["ClowdApp", "ClowdJob", "ClowdJobInvocation"]


### PR DESCRIPTION
some apps use CPU_LIMIT, CPU_REQUEST env vars, current regex expects at leas 1 character  after LIMIT/REQUEST keyword

example of env vars in sha-extractor
https://github.com/RedHatInsights/insights-sha-extractor/blob/master/deploy/clowdapp.yaml#L280-L287