### PR TITLE
Check that both requests and limits are set for a trusted resource config

### DIFF
--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -89,11 +89,15 @@ if os.getenv("BONFIRE_TRUSTED_COMPONENTS"):
     TRUSTED_COMPONENTS = os.getenv("BONFIRE_TRUSTED_COMPONENTS").split(",")
 
 # regexes used to check for trusted resource request/limit
-TRUSTED_REGEX_FOR_PATH = {
-    "resources.requests.cpu": r"\${(CPU_REQUEST[A-Z0-9_]*)}",
-    "resources.limits.cpu": r"\${(CPU_LIMIT[A-Z0-9_]*)}",
-    "resources.requests.memory": r"\${(MEM(?:ORY)?_REQUEST[A-Z0-9_]*)}",
-    "resources.limits.memory": r"\${(MEM(?:ORY)?_LIMIT[A-Z0-9_]*)}",
+TRUSTED_RESOURCE_REGEX = {
+    "requests": {
+        "cpu": r"\${(CPU_REQUEST[A-Z0-9_]*)}",  # noformat
+        "memory": r"\${(MEM(?:ORY)?_REQUEST[A-Z0-9_]*)}",
+    },
+    "limits": {
+        "cpu": r"\${(CPU_LIMIT[A-Z0-9_]*)}",  # noformat
+        "memory": r"\${(MEM(?:ORY)?_LIMIT[A-Z0-9_]*)}",
+    },
 }
 
 TRUSTED_CHECK_KINDS = ["ClowdApp", "ClowdJob", "ClowdJobInvocation"]

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -46,7 +46,6 @@ def _get_trusted_config(data: dict, key1: str, key2: str, path: str, component_p
         raise ValueError("not able to find conf.TRUSTED_RESOURCE_REGEX[{key1}][{key2}]")
 
     value = data.get(key1, {}).get(key2)
-    print(data)
     if value:
         match = False
         in_params = False
@@ -88,9 +87,9 @@ def _remove_untrusted_configs(
     if path.endswith(".resources"):
         resources = current_dict["resources"]
         cpu_request = _get_trusted_config(resources, "requests", "cpu", path, params)
-        cpu_limit = _get_trusted_config(resources, "requests", "cpu", path, params)
-        mem_request = _get_trusted_config(resources, "requests", "cpu", path, params)
-        mem_limit = _get_trusted_config(resources, "requests", "cpu", path, params)
+        cpu_limit = _get_trusted_config(resources, "limits", "cpu", path, params)
+        mem_request = _get_trusted_config(resources, "requests", "memory", path, params)
+        mem_limit = _get_trusted_config(resources, "limits", "memory", path, params)
 
         if any([cpu_request, cpu_limit]) and not all([cpu_request, cpu_limit]):
             log.debug("'%s' cpu config needs both request and limit, removing cpu config", path)

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -155,7 +155,7 @@ parameters:
 
 TEMPLATES = {
     "simple_clowdapp": SIMPLE_CLOWDAPP,
-    "clowdapp_w_untrusted_param": "CLOWDAPP_W_UNTRUSTED_PARAM",
+    "clowdapp_w_untrusted_param": CLOWDAPP_W_UNTRUSTED_PARAM,
 }
 
 


### PR DESCRIPTION
In some cases only the resource limit or only the resource request is being set. Or in other cases, bonfire will remove one of these settings because it finds the parameter name to be un-trusted. If bonfire strips either the limit or the request of the resource config, it causes Clowder to use the environment default for the other one. If the request:limit ratio is off, then the pod won't spin up. This causes problems in the ephemeral environment.

This PR enforces that both request and limit must be present in a resource configuration.