### PR TITLE
Change default ref environment to 'insights-production'

### DIFF
--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -73,7 +73,7 @@ BONFIRE_NS_REQUESTER = os.getenv("BONFIRE_NS_REQUESTER")
 BONFIRE_BOT = os.getenv("BONFIRE_BOT", "false").lower() == "true"
 
 BONFIRE_DEFAULT_PREFER = str(os.getenv("BONFIRE_DEFAULT_PREFER", "ENV_NAME=frontends")).split(",")
-BONFIRE_DEFAULT_REF_ENV = str(os.getenv("BONFIRE_DEFAULT_REF_ENV", "insights-stage"))
+BONFIRE_DEFAULT_REF_ENV = str(os.getenv("BONFIRE_DEFAULT_REF_ENV", "insights-production"))
 BONFIRE_DEFAULT_FALLBACK_REF_ENV = str(
     os.getenv("BONFIRE_DEFAULT_FALLBACK_REF_ENV", "insights-stage")
 )


### PR DESCRIPTION
Changing the default reference environment to 'production' so that ephemeral envs are able to pull container images with more reliability. The stage image builds are unreliable.