### PR TITLE
Merge remote and local app configs after setting git refs

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -951,6 +951,14 @@ def _get_apps_config(
         log.info("fetching apps config using source: %s", source)
         apps_config = get_appsfile_apps(config)
 
+    # handle git ref/image substitutions if reference environment was provided
+    if ref_env:
+        apps_config = sub_refs(apps_config, ref_env, fallback_ref_env, preferred_params)
+
+    # merge remote apps config with local app config
+    local_apps = get_local_apps(config)
+    apps_config = merge_app_configs(apps_config, local_apps, local_config_method)
+
     # validate the components look ok after merging
     for app_name, app_config in apps_config.items():
         for component in app_config["components"]:
@@ -962,14 +970,6 @@ def _get_apps_config(
             except FatalError as err:
                 # re-raise with a bit more context
                 raise FatalError(f"{str(err)}, hit on app {app_name}")
-
-    # handle git ref/image substitutions if reference environment was provided
-    if ref_env:
-        apps_config = sub_refs(apps_config, ref_env, fallback_ref_env, preferred_params)
-
-    # merge remote apps config with local app config
-    local_apps = get_local_apps(config)
-    apps_config = merge_app_configs(apps_config, local_apps, local_config_method)
 
     return apps_config
 

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -951,10 +951,6 @@ def _get_apps_config(
         log.info("fetching apps config using source: %s", source)
         apps_config = get_appsfile_apps(config)
 
-    # merge remote apps config with local app config
-    local_apps = get_local_apps(config)
-    apps_config = merge_app_configs(apps_config, local_apps, local_config_method)
-
     # validate the components look ok after merging
     for app_name, app_config in apps_config.items():
         for component in app_config["components"]:
@@ -970,6 +966,10 @@ def _get_apps_config(
     # handle git ref/image substitutions if reference environment was provided
     if ref_env:
         apps_config = sub_refs(apps_config, ref_env, fallback_ref_env, preferred_params)
+
+    # merge remote apps config with local app config
+    local_apps = get_local_apps(config)
+    apps_config = merge_app_configs(apps_config, local_apps, local_config_method)
 
     return apps_config
 

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -651,9 +651,7 @@ class TemplateProcessor:
             # override template ref if requested
             self._sub_ref(component_name, rf)
             log.debug(
-                "component: '%s' fetching template using git ref '%s'",
-                component_name,
-                rf.ref
+                "component: '%s' fetching template using git ref '%s'", component_name, rf.ref
             )
             commit, template_content = rf.fetch()
         except Exception as err:

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -650,6 +650,11 @@ class TemplateProcessor:
             rf = RepoFile.from_config(component)
             # override template ref if requested
             self._sub_ref(component_name, rf)
+            log.debug(
+                "component: '%s' fetching template using git ref '%s'",
+                component_name,
+                rf.ref
+            )
             commit, template_content = rf.fetch()
         except Exception as err:
             log.error("failed to fetch template file for %s", component_name)

--- a/bonfire/qontract.py
+++ b/bonfire/qontract.py
@@ -394,7 +394,7 @@ def _find_ref_target_and_update_component(
             final_component["parameters"].update(image_tags)
 
         log.debug(
-            "%s using git ref/image tag from env '%s': %s%s",
+            "%s git ref/image tag found for env '%s': %s%s",
             log_prefix,
             ref_env,
             final_component["ref"],

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -1,9 +1,11 @@
 import atexit
 import copy
+import difflib
 from functools import lru_cache
 import json
 import logging
 import os
+import pprint
 import re
 import shlex
 import socket
@@ -12,8 +14,6 @@ import tempfile
 import time
 from urllib.request import urlretrieve
 import sys
-import difflib
-import pprint
 
 if sys.version_info >= (3, 8):
     import importlib.metadata as importlib_metadata

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -12,6 +12,8 @@ import tempfile
 import time
 from urllib.request import urlretrieve
 import sys
+import difflib
+import pprint
 
 if sys.version_info >= (3, 8):
     import importlib.metadata as importlib_metadata
@@ -637,14 +639,25 @@ def object_merge(old, new, merge_lists=True):
     return new
 
 
+def _log_diff(old_apps_config, new_apps_config):
+    old_lines = pprint.pformat(old_apps_config).splitlines()
+    new_lines = pprint.pformat(new_apps_config).splitlines()
+    compare_result = difflib.unified_diff(old_lines, new_lines)
+    diff = "\n".join(compare_result)
+    log.info("diff in apps config after merging local config into remote config:\n%s", diff)
+
+
 def merge_app_configs(apps_config, new_apps, method="merge"):
     """
     Merge configurations found in new_apps into apps_config
     """
+    old_apps_config = copy.deepcopy(apps_config)
+
     if method == "override":
         # with this method, any app defined in 'new_apps' completely overrides
         # the config in 'apps_config'
         apps_config.update(new_apps)
+        _log_diff(old_apps_config, apps_config)
         return apps_config
 
     for app_name, new_app_cfg in new_apps.items():
@@ -685,4 +698,5 @@ def merge_app_configs(apps_config, new_apps, method="merge"):
                     f"more than once in app '{app_name}'"
                 )
 
+    _log_diff(old_apps_config, apps_config)
     return apps_config

--- a/tests/test_app_configs.py
+++ b/tests/test_app_configs.py
@@ -384,14 +384,14 @@ def test_local_config_merge(monkeypatch, source):
     actual = _get_apps_config(
         source=source,
         target_env="test_target_env",
-        ref_env=None,
+        ref_env="test_ref_env",
         fallback_ref_env=None,
         local_config_path="na",
         local_config_method="merge",
         preferred_params={},
     )
 
-    expected = _target_apps()
+    expected = _target_apps_w_refs_subbed()
     for _, app_config in expected.items():
         for component in app_config["components"]:
             if component["name"] == "appBcomponent1":
@@ -430,14 +430,14 @@ def test_local_config_override(monkeypatch, source):
     actual = _get_apps_config(
         source=source,
         target_env="test_target_env",
-        ref_env=None,
+        ref_env="test_ref_env",
         fallback_ref_env=None,
         local_config_path="na",
         local_config_method="override",
         preferred_params={},
     )
 
-    expected = _target_apps()
+    expected = _target_apps_w_refs_subbed()
     expected["appB"] = app_b
 
     assert actual == expected
@@ -467,14 +467,14 @@ def test_local_config_merge_update_param(monkeypatch, source):
     actual = _get_apps_config(
         source=source,
         target_env="test_target_env",
-        ref_env=None,
+        ref_env="test_ref_env",
         fallback_ref_env=None,
         local_config_path="na",
         local_config_method="merge",
         preferred_params={},
     )
 
-    expected = _target_apps()
+    expected = _target_apps_w_refs_subbed()
     component1_found = False
     for _, app_config in expected.items():
         for component in app_config["components"]:

--- a/tests/test_app_configs.py
+++ b/tests/test_app_configs.py
@@ -299,7 +299,7 @@ def test_empty_local_config(monkeypatch, source, local_config_method):
 def test_bad_local_config(monkeypatch, source, local_config_method, bad_local_cfg):
     _setup_monkeypatch(monkeypatch, source, bad_local_cfg)
     with pytest.raises(bonfire.utils.FatalError) as exc:
-        _get_apps_config(
+        output = _get_apps_config(
             source=source,
             target_env="test_env_with_no_apps",
             ref_env=None,
@@ -308,6 +308,8 @@ def test_bad_local_config(monkeypatch, source, local_config_method, bad_local_cf
             local_config_method=local_config_method,
             preferred_params={},
         )
+        from pprint import pprint
+        pprint(output)
         assert str(exc).startswith(bonfire.utils.SYNTAX_ERR)
 
 

--- a/tests/test_app_configs.py
+++ b/tests/test_app_configs.py
@@ -299,7 +299,7 @@ def test_empty_local_config(monkeypatch, source, local_config_method):
 def test_bad_local_config(monkeypatch, source, local_config_method, bad_local_cfg):
     _setup_monkeypatch(monkeypatch, source, bad_local_cfg)
     with pytest.raises(bonfire.utils.FatalError) as exc:
-        output = _get_apps_config(
+        _get_apps_config(
             source=source,
             target_env="test_env_with_no_apps",
             ref_env=None,
@@ -308,8 +308,6 @@ def test_bad_local_config(monkeypatch, source, local_config_method, bad_local_cf
             local_config_method=local_config_method,
             preferred_params={},
         )
-        from pprint import pprint
-        pprint(output)
         assert str(exc).startswith(bonfire.utils.SYNTAX_ERR)
 
 

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -24,6 +24,10 @@ class MockRepoFile:
     def add_template(cls, name, template_commit, template_data):
         cls.templates[name] = {"commit": template_commit, "data": template_data}
 
+    @property
+    def ref(self):
+        return self.templates[self.name]["commit"]
+
     def fetch(self):
         return self.templates[self.name]["commit"], self.templates[self.name]["data"]
 


### PR DESCRIPTION
Fixes #441

If a git ref is set on a component in the local config, it should take precedence over the remote config.

* Wait to merge remote config with local config until AFTER we set the git refs for all components
* Add better debug logging around the config merge
* Tweak unit tests to properly test this scenario