### PR TITLE
Frontend context name ephemeral value

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,19 @@ podman run -it --rm --userns=keep-id:uid=1000,gid=1000 -v $HOME/.kube/config:/op
     quay.io/cloudservices/bonfire namespace list
 ```
 
+# Local development
+
+To install local changes and use local version of bonfire, switch to the root directory of this repository, switch to virtual environment and install bonfire package with local changes:
+
+```bash
+VENV_DIR=~/bonfire_venv
+mkdir -p $VENV_DIR
+python3 -m venv $VENV_DIR
+. $VENV_DIR/bin/activate
+pip install -e .
+```
+
+
 # Quick Start
 
 Start with `bonfire --help` to familiarize yourself with the basic command groups. Don't forget to use the `--help` flag on sub-commmands as well if you are curious to learn more about different CLI commands, options, and arguments.

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -672,6 +672,8 @@ class TemplateProcessor:
 
         # always override ENV_NAME
         params["ENV_NAME"] = self.clowd_env
+        # TODO: revisit need for below param once FEO has a more developed config management system
+        params["FRONTEND_CONTEXT_NAME"] = self.clowd_env
 
         # override other specific parameters on this component if requested by user at runtime
         self._sub_params(component_name, params)


### PR DESCRIPTION
This change is required for the Frontend operator features and is a pre-requisite for opening the migrations to the new features for HCC tenants.

### Why
By default, FEO generates a config map to the Frontend namespace(s). In stage/prod, this config map is also injected into other namespaces(s) with a deterministic name and used there. However because in EE all deployments are in the same namespace, we need to set the parameter `FRONTEND_CONTEXT_NAME` set to the `clowd_env` value in order to properly inject the config map value into specific pods (the deployment use the FRONTEND_CONTEXT_NAME env variable to get the name of the config map).

There is already one place in the processor.py where this parameter is configured however, it turns out it's needed in one additional place.

We will need a new version of bonfire to be released so it can be added to the Frontend migration guide.