### PR TITLE
rearranging tasks, fixing task image name

### DIFF
--- a/.tekton/bonfire-push.yaml
+++ b/.tekton/bonfire-push.yaml
@@ -415,7 +415,7 @@ spec:
         - name: name
           value: coverity-availability-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check-oci-ta:0.2@sha256:02c0d3696efc7d84fd3e00923a4919bfeacde09ba9c3ff4625a57748aa7db3de
+          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:02c0d3696efc7d84fd3e00923a4919bfeacde09ba9c3ff4625a57748aa7db3de
         - name: kind
           value: task
         resolver: bundles
@@ -458,7 +458,7 @@ spec:
         - name: name
           value: sast-coverity-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:91ba738df7ec548d4127163e07a88de06568a350fbf581405cc8fc8498f6153c
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.2@sha256:61a4b5afd0c49cd999fbe60b36e2d92750c7fb337942015929b3d3f393e3bde5
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/bonfire-push.yaml
+++ b/.tekton/bonfire-push.yaml
@@ -415,7 +415,7 @@ spec:
         - name: name
           value: coverity-availability-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:02c0d3696efc7d84fd3e00923a4919bfeacde09ba9c3ff4625a57748aa7db3de
+          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:91ba738df7ec548d4127163e07a88de06568a350fbf581405cc8fc8498f6153c
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
**Description**

The purpose of this PR is to update the names for the `sast-coverity-check` and `coverity-availability-check` tasks to fix the failures in the on push pipeline.