### PR TITLE
updating name of bundle for the sast coverity check

### DIFF
--- a/.tekton/bonfire-push.yaml
+++ b/.tekton/bonfire-push.yaml
@@ -456,7 +456,7 @@ spec:
       taskRef:
         params:
         - name: name
-          value: sast-coverity-check
+          value: sast-coverity-check-oci-ta
         - name: bundle
           value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.2@sha256:61a4b5afd0c49cd999fbe60b36e2d92750c7fb337942015929b3d3f393e3bde5
         - name: kind


### PR DESCRIPTION
**Description**

The `sast-coverity-check` task's bundle name was incorrect for the bundle being used. We need to update this from `sast-coverity-check` to `sast-coverity-check-oci-ta` in the push pipeline for this to succeed. 
