### PR TITLE
Pass NAMESPACE param if unset, fix bugs in resource waiter

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -1023,6 +1023,7 @@ def _process(
     local,
     frontends,
     preferred_params,
+    namespace,
 ):
     apps_config = _get_apps_config(
         source,
@@ -1051,6 +1052,7 @@ def _process(
         component_filter,
         local,
         frontends,
+        namespace,
     )
     return processor.process()
 
@@ -1132,6 +1134,7 @@ def _cmd_process(
         local,
         frontends,
         preferred_params,
+        namespace,
     )
     print(json.dumps(processed_templates, indent=2))
 
@@ -1384,6 +1387,7 @@ def _cmd_config_deploy(
             local,
             frontends,
             preferred_params,
+            namespace,
         )
         log.debug("app configs:\n%s", json.dumps(apps_config, indent=2))
         if not apps_config["items"]:

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -558,6 +558,7 @@ class TemplateProcessor:
         component_filter,
         local,
         frontends,
+        namespace=None,
     ):
         self.apps_config = apps_config
         self.requested_app_names = self._parse_app_names(app_names)
@@ -575,6 +576,7 @@ class TemplateProcessor:
         self.component_filter = component_filter
         self.local = local
         self.frontends = frontends
+        self.namespace = namespace
 
         self._validate()
 
@@ -669,6 +671,10 @@ class TemplateProcessor:
         # set IMAGE_TAG on this component only if it is currently unset
         if "IMAGE_TAG" not in params:
             params["IMAGE_TAG"] = commit[:7]
+
+        # set NAMESPACE on this component only if it is current unset
+        if "NAMESPACE" not in params:
+            params["NAMESPACE"] = self.namespace
 
         # always override ENV_NAME
         params["ENV_NAME"] = self.clowd_env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "importlib-resources; python_version<'3.9'",
     "junitparser",
     "multidict",
-    "ocviapy>=1.3.1",
+    "ocviapy>=1.4.0",
     "python-dotenv",
     "PyYAML",
     "requests",


### PR DESCRIPTION
This PR handles 3 things:

* If NAMESPACE parameter is unset, pass it into templates during processing (similar to how we handle IMAGE_TAG)
* Fix bugs found with resource waiter:
    * If there are no ClowdApps/ClowdEnvironments, the ResourceWatcher did not have enough time to fetch resources from the kubernetes API. This caused `_all_resources_ready` to think that there were no additional resources left to wait on. This fix is to fetch all resources initially with a "blocking" call before starting the background thread.
    * `wait_for_all_resources` does not need to enclose `_all_resources_ready` in a `wait_for()` function. This is because `_all_resources_ready` was modified some time ago to keep lowering the timeout as it moves through each "phase". By using `wait_for` in `_all_resources_ready`, if the `_all_resources_ready` returned False before `timeout` was hit (even by a small fraction), `_all_resources_ready` would get re-executed again (and wait for another 10 minutes). That's not the behavior we want. 
* Upgrade ocviapy to v1.4.0 (this adds a new function which helps with the above)

