### PR TITLE
add cli parameter that exclude components to deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,11 @@ bonfire deploy advisor --set-parameter advisor-backend/REPLICAS=3
 bonfire deploy advisor --set-image-tag quay.io/cloudservices/advisor-backend=my_tag
 ```
 
+* Exclude components of a app
+```
+bonfire deploy advisor --exclude-components advisor-backend-component
+```
+
 # Commonly Used CLI Options
 ## Deploying/Processing
 
@@ -230,6 +235,7 @@ bonfire deploy advisor --set-image-tag quay.io/cloudservices/advisor-backend=my_
 * `--set-parameter <component>/<name>=<value>` -- use this to set a parameter value on a specific component's template.
 * `--optional-deps-method <hybrid|all|none>` -- change the way that bonfire processes ClowdApp optional dependencies (see "Dependency Processing" section)
 * `--prefer PARAM_NAME=PARAM_VALUE` -- in cases where bonfire finds more than one deployment target, use this to set the parameter names and values that should be used to select a "preferred" deployment target. This option can be passed in multiple times. `bonfire` will select the target with the highest amount of "preferred parameters" on it. Default is currently set to `ENV_NAME=frontends` to select "stable" frontends in the consoledot environments.
+* `--exclude-components` -- exclude a list of components to prevent them from being processed and deployed.
 
 ## Trusted/Untrusted Resource Configurations
 

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -1029,6 +1029,7 @@ def _process(
     frontends,
     preferred_params,
     namespace,
+    exclude_components,
 ):
     apps_config = _get_apps_config(
         source,
@@ -1058,6 +1059,7 @@ def _process(
         local,
         frontends,
         namespace,
+        exclude_components,
     )
     return processor.process()
 
@@ -1308,6 +1310,11 @@ def _deploy_err_handler(err, no_release_on_fail, reserved_new_ns, reserve, ns):
     is_flag=True,
     help="Do not release namespace reservation if deployment fails",
 )
+@click.option(
+    "--exclude-components",
+    type=str,
+    help="Comma-separated list of components to exclude from deployment.",
+)
 @options(_ns_reserve_options)
 @options(_timeout_options)
 def _cmd_config_deploy(
@@ -1336,6 +1343,7 @@ def _cmd_config_deploy(
     duration,
     timeout,
     no_release_on_fail,
+    exclude_components,
     component_filter,
     import_secrets,
     import_configmaps,
@@ -1405,6 +1413,7 @@ def _cmd_config_deploy(
             frontends,
             preferred_params,
             namespace,
+            exclude_components,
         )
         log.debug("app configs:\n%s", json.dumps(apps_config, indent=2))
         if not apps_config["items"]:

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -600,6 +600,11 @@ _process_options = _app_source_options + [
         multiple=True,
     ),
     click.option(
+        "--exclude-components",
+        type=str,
+        help="Comma-separated list of components to exclude from deployment",
+    ),
+    click.option(
         "--frontends",
         "-F",
         help="Deploy frontends (default: false)",
@@ -1114,6 +1119,7 @@ def _cmd_process(
     local,
     frontends,
     preferred_params,
+    exclude_components,
 ):
     """Fetch and process application templates"""
     clowd_env = _get_env_name(namespace, clowd_env)
@@ -1142,6 +1148,7 @@ def _cmd_process(
         frontends,
         preferred_params,
         namespace,
+        exclude_components,
     )
     print(json.dumps(processed_templates, indent=2))
 
@@ -1309,11 +1316,6 @@ def _deploy_err_handler(err, no_release_on_fail, reserved_new_ns, reserve, ns):
     "--no-release-on-fail",
     is_flag=True,
     help="Do not release namespace reservation if deployment fails",
-)
-@click.option(
-    "--exclude-components",
-    type=str,
-    help="Comma-separated list of components to exclude from deployment.",
 )
 @options(_ns_reserve_options)
 @options(_timeout_options)

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -3,6 +3,7 @@ import json
 import logging
 import re
 import traceback
+from typing import Optional
 import uuid
 from pathlib import Path
 
@@ -388,6 +389,23 @@ class TemplateProcessor:
         return parsed_app_names
 
     @staticmethod
+    def _parse_exclude_components(exclude_components):
+        """Parse exclude_components which can be None, a string, or a list."""
+        if exclude_components is None:
+            return None
+
+        if isinstance(exclude_components, str):
+            # Handle comma-separated string
+            return [
+                component.strip()
+                for component in exclude_components.split(",")
+                if component.strip()
+            ]
+
+        # Assume it's already a list
+        return list(exclude_components)
+
+    @staticmethod
     def _find_dupe_components(components_for_app):
         """Make sure no component is listed more than once across all apps."""
         for app_name, components in components_for_app.items():
@@ -559,6 +577,7 @@ class TemplateProcessor:
         local,
         frontends,
         namespace=None,
+        exclude_components=None,
     ):
         self.apps_config = apps_config
         self.requested_app_names = self._parse_app_names(app_names)
@@ -577,6 +596,7 @@ class TemplateProcessor:
         self.local = local
         self.frontends = frontends
         self.namespace = namespace
+        self.exclude_components = self._parse_exclude_components(exclude_components)
 
         self._validate()
 
@@ -841,12 +861,28 @@ class TemplateProcessor:
         for component in app_cfg["components"]:
             component_name = component["name"]
             log.debug("app '%s' has component '%s'", app_name, component_name)
-            if self.component_filter and component_name not in self.component_filter:
-                log.debug(
-                    "skipping component '%s', not found in --component filter", component_name
-                )
+            reason = self._component_skip_check(component_name)
+            if reason:
+                log.info("skipping component '%s', %s", component_name, reason)
                 continue
             self._process_component(component_name, app_name, in_recursion=False)
+
+    def _component_skip_check(self, component_name) -> Optional[str]:
+        skip_reasons = [
+            (
+                self.component_filter and component_name not in self.component_filter,
+                "not found in --component filter",
+            ),
+            (
+                self.exclude_components and component_name in self.exclude_components,
+                "found in --exclude-components list",
+            ),
+        ]
+
+        for condition, reason in skip_reasons:
+            if condition:
+                return reason
+        return None
 
     def process(self, app_names=None):
         if not app_names:


### PR DESCRIPTION
This PR adds a new CLI argument `--exclude-components`, which accepts a comma-separated list of components to be skipped by the processor so they are not deployed.