### PR TITLE
Make sure the 'org' value uses %2F for / when formatted into paths

### DIFF
--- a/bonfire/qontract.py
+++ b/bonfire/qontract.py
@@ -238,9 +238,15 @@ def _add_component(
     host = "github" if "github" in url else "gitlab"
 
     try:
-        parsed_url_parts = urlparse(url).path.strip("/").split("/")
-        org = parsed_url_parts[0]
-        repo = "/".join(parsed_url_parts[1:])  # supports gitlab subgroups
+        repo_path = urlparse(url).path.strip("/")
+        # Gitlab allows the 'group' to include subgroups: e.g.
+        # http://my-gitlab.com/group/subgroup/my-repo would translate to:
+        #   org = group/subgroup
+        #   repo = my-repo
+        last_slash_pos = repo_path.rindex("/")
+        org = repo_path[:last_slash_pos]
+        next_after_slash = last_slash_pos + 1
+        repo = repo_path[next_after_slash:]
     except (ValueError, IndexError) as err:
         raise ValueError(f"invalid repo url '{url}': {err}")
 

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -188,7 +188,8 @@ class RepoFile:
             # {..'org' group including subgroup...}/{.......repo...........}
             last_slash_pos = repo.rindex("/")
             org = repo[:last_slash_pos]
-            repo = repo[last_slash_pos+1:]
+            next_after_slash = last_slash_pos + 1
+            repo = repo[next_after_slash:]
         elif d["host"] == "local":
             org = "local"
 

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -159,8 +159,8 @@ class RepoFile:
         self.host = host
         self.org = org
         # Note: the group may include a slash, so we need to quote it
-        # (changing the / to %27) if necessary.
-        self.safe_org = quote(org, safe='')
+        # (changing the / to %2F) if necessary.
+        self.safe_org = quote(org, safe="")
         self.repo = repo
         self.path = path
         self.ref = ref

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -183,8 +183,12 @@ class RepoFile:
                     f"{SYNTAX_ERR}, invalid value for repo '{repo}', required format: "
                     "<org>/<repo name>"
                 )
-            org = repo.split("/")[0]
-            repo = "/".join(repo.split("/")[1:])  # supports gitlab subgroups
+            # Gitlab allows the 'group' to include subgroups: in e.g.
+            # insights-platform/insights-operations/advisor-backend-internal
+            # {..'org' group including subgroup...}/{.......repo...........}
+            last_slash_pos = repo.rindex("/")
+            org = repo[:last_slash_pos]
+            repo = repo[last_slash_pos+1:]
         elif d["host"] == "local":
             org = "local"
 

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -306,7 +306,9 @@ class RepoFile:
             # look up the commit hash for this branch
             commit = self._get_gl_commit_hash()
 
-        url = GL_RAW_URL.format(group=self.safe_org, project=self.repo, ref=commit, path=self.path)
+        # Note that the raw URL alone allows '/' in the group section of the
+        # path, so we don't use self.safe_org here.
+        url = GL_RAW_URL.format(group=self.org, project=self.repo, ref=commit, path=self.path)
         check_url_connection(url)
         response = self._get(url, verify=self._gl_certfile)
         if response.status_code == 404:


### PR DESCRIPTION
For no readily apparent reason, we recently had to create a project with the
'org' part of the path as 'insights-platform/insights-operations'.  This unfortunately
causes gitlab to get confused, because it parses that as the 'insights-platform'
org and then the rest of the line doesn't match what it expects.  So we need to
URL escape the `/` in the 'org' value.