### PR TITLE
Handle gitlab subgroups

### DIFF
--- a/bonfire/qontract.py
+++ b/bonfire/qontract.py
@@ -238,8 +238,9 @@ def _add_component(
     host = "github" if "github" in url else "gitlab"
 
     try:
-        parsed_url = urlparse(url)
-        org, repo = parsed_url.path.rstrip("/").split("/")[-2:]
+        parsed_url_parts = urlparse(url).path.strip("/").split("/")
+        org = parsed_url_parts[0]
+        repo = "/".join(parsed_url_parts[1:])  # supports gitlab subgroups
     except (ValueError, IndexError) as err:
         raise ValueError(f"invalid repo url '{url}': {err}")
 

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -180,7 +180,8 @@ class RepoFile:
                     f"{SYNTAX_ERR}, invalid value for repo '{repo}', required format: "
                     "<org>/<repo name>"
                 )
-            org, repo = repo.split("/")
+            org = repo.split("/")[0]
+            repo = "/".join(repo.split("/")[1:])  # supports gitlab subgroups
         elif d["host"] == "local":
             org = "local"
 


### PR DESCRIPTION
Adds support for repo URLs which have the format `https://gitlab/group/subgroup/repo`