### PR TITLE
Simplify and improve the `hms_to_seconds` function

### DIFF
--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -598,16 +598,14 @@ def hms_to_seconds(s):
 
     seconds = 0
 
-    if not split:
-        return seconds
-
-    parts = split.groupdict()
-    if parts["hours"]:
-        seconds += int(parts["hours"]) * 3600
-    if parts["minutes"]:
-        seconds += int(parts["minutes"]) * 60
-    if parts["seconds"]:
-        seconds += int(parts["seconds"])
+    if split:
+        parts = split.groupdict()
+        if parts["hours"]:
+            seconds += int(parts["hours"]) * 3600
+        if parts["minutes"]:
+            seconds += int(parts["minutes"]) * 60
+        if parts["seconds"]:
+            seconds += int(parts["seconds"])
 
     return seconds
 

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -602,12 +602,12 @@ def hms_to_seconds(s):
         return seconds
 
     parts = split.groupdict()
-    if parts['hours']:
-        seconds += int(parts['hours']) * 3600
-    if parts['minutes']:
-        seconds += int(parts['minutes']) * 60
-    if parts['seconds']:
-        seconds += int(parts['seconds'])
+    if parts["hours"]:
+        seconds += int(parts["hours"]) * 3600
+    if parts["minutes"]:
+        seconds += int(parts["minutes"]) * 60
+    if parts["seconds"]:
+        seconds += int(parts["seconds"])
 
     return seconds
 

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -598,6 +598,9 @@ def hms_to_seconds(s):
 
     seconds = 0
 
+    if not split:
+        return seconds
+
     parts = split.groupdict()
     if parts['hours']:
         seconds += int(parts['hours']) * 3600

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -592,20 +592,19 @@ def check_pypi():
 
 
 def hms_to_seconds(s):
-    fmt = r"^(\d+h)?(\d+m)?(\d+s)?$"
+    fmt = r"^(?:(?P<hours>\d+)h)?(?:(?P<minutes>\d+)m)?(?:(?P<seconds>\d+)s)?$"
 
-    split = re.split(fmt, s)
+    split = re.match(fmt, s)
 
     seconds = 0
 
-    for group in split:
-        if group:  # to ignore 'None' groups when all units aren't present
-            if "h" in group:
-                seconds += int(group.split("h")[0]) * 3600
-            elif "m" in group:
-                seconds += int(group.split("m")[0]) * 60
-            elif "s" in group:
-                seconds += int(group.split("s")[0])
+    parts = split.groupdict()
+    if parts['hours']:
+        seconds += int(parts['hours']) * 3600
+    if parts['minutes']:
+        seconds += int(parts['minutes']) * 60
+    if parts['seconds']:
+        seconds += int(parts['seconds'])
 
     return seconds
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -70,6 +70,7 @@ def test_get_version():
         ("45m", 2700),
         ("65s", 65),
         ("1h30m", 5400),
+        ("foo", 0),
     ],
 )
 def test_hms_to_seconds(seconds: str, expected: int):


### PR DESCRIPTION
In passing I found a way to simplify and improve the `hms_to_seconds`
function by using the regular expression parser to pull the hour, minute
and seconds values out directly.  I also made sure it was tested against
invalid input.