### PR TITLE
adds uv tool install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ echo 'GITHUB_TOKEN=<your api token>' >> ~/.config/bonfire/env
 In addition, since some projects may be private, you will need to add the `repo` (full control of private repositories) scope too.
 for the template fetching to work!
 
+## Using UV
+
+If you have `uv` installed on your system, you can also quickly install the bonfire tool globally on your system with:
+```
+uv tool install crc-bonfire
+```
+
 ## Using homebrew
 
 ```bash


### PR DESCRIPTION
I found this installation method to be extremely simple, so I wanted to add it to the documentation. This is for the casual end-user who may not want to muck around with virtual environments† and python versions and the dependencies between those.

† - "may not want to muck around with virtual environments" meaning at face value. UV does this under the hood, but that's abstracted to the end-user and this should "just work" just like any other system binary. 