### PR TITLE
add console url to namespace describe output

### DIFF
--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -1,8 +1,8 @@
-import copy
-import json
-import datetime
-import logging
 import base64
+import copy
+import datetime
+import json
+import logging
 
 from ocviapy import apply_config, get_all_namespaces, get_json, on_k8s, set_current_namespace
 from wait_for import TimedOutError
@@ -10,14 +10,13 @@ from wait_for import TimedOutError
 import bonfire.config as conf
 from bonfire.openshift import (
     get_all_reservations,
-    get_reservation,
     get_console_url,
+    get_reservation,
     wait_on_reservation,
     whoami,
 )
 from bonfire.processor import process_reservation
 from bonfire.utils import FatalError, hms_to_seconds
-
 
 log = logging.getLogger(__name__)
 
@@ -390,6 +389,7 @@ def describe_namespace(project_name: str, output: str):
     project_url = get_console_url()
 
     data = f"\nCurrent project: {project_name}\n"
+    ns_url = ""
     if project_url:
         ns_url = f"{project_url}/k8s/cluster/projects/{project_name}"
         data += f"Project URL: {ns_url}\n"
@@ -410,6 +410,8 @@ def describe_namespace(project_name: str, output: str):
             "default_password": kc_creds["defaultPassword"],
             "gateway_route": f"https://{fe_host}",
         }
+        if ns_url:
+            data["console_namespace_route"] = ns_url
         data = json.dumps(data, indent=2)
 
     return data


### PR DESCRIPTION
This PR adds `console_namespace_route` to the json output from `namespace describe`

```
$ bonfire namespace describe -o json                       
2025-08-06 12:42:03 [    INFO] [          MainThread] attempting to use current namespace from oc/kubectl context...
2025-08-06 12:42:05 [    INFO] [          MainThread] running (pid 14171): oc project -q 
2025-08-06 12:42:05 [    INFO] [           pid-14171]  |stdout| ephemeral-bckr8k
{
  "namespace": "ephemeral-bckr8k",
  "keycloak_admin_route": "https://ee-z2g5icl3-auth.apps.crc-eph.r9lp.p1.openshiftapps.com/auth/",
  ...,
  "console_namespace_route": "https://console-openshift-console.apps.crc-eph.r9lp.p1.openshiftapps.com/k8s/cluster/projects/ephemeral-bckr8k"
}
```