### PR TITLE
Namespace option at Root or subcommands

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -116,17 +116,16 @@ def click_exception_wrapper(command):
 
 
 _global_options = [
-    click.option("--debug", "-d", help="Enable debug logging", is_flag=True, default=False),
     click.option("--namespace", "-n", help="Namespace to use", default=None),
 ]
 
 @click.group(context_settings=dict(help_option_names=["-h", "--help"]))
 @options(_global_options)
 @click.pass_context
+@click.option("--debug", "-d", help="Enable debug logging", is_flag=True, default=False)
 def main(ctx, debug, namespace):
     # Store debug flag in context for subcommands to access
     ctx.ensure_object(dict)
-    ctx.obj['debug'] = debug
     ctx.obj['namespace'] = namespace
     
     logging.getLogger("sh").setLevel(logging.CRITICAL)  # silence the 'sh' library logger


### PR DESCRIPTION
The purpose of this PR is to address https://github.com/RedHatInsights/bonfire/issues/217.
To do this we add the namespace option to the root command and remove the required status from the sub commands. For those sub commands we do a check if the namespace was provided at the root or the subcommand.

Unfortunately we can't do the same for the debug option. In click the root command gets processed first, you can't pass the context back up to the root.