### PR TITLE
Allow fine-grained control over dependency removal

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -366,27 +366,39 @@ def _validate_split_equals(ctx, param, value):
         raise click.BadParameter(msg)
 
 
-def _translate_to_obj(value_list):
+def _translate_to_obj(value_list, param_name):
     apps = []
     components = []
     select_all = False
+    # By default, we don't want to remove any dependencies
+    selector_options = ["remove_dependencies", "no_remove_dependencies"]
     for value in value_list:
         if value == "all":
             # all is a special keyword
             select_all = True
         elif value.startswith("app:"):
             apps.append(value.split(":")[1])
+        elif "/" in value and param_name not in selector_options:
+            raise click.BadParameter("dependency specifiers are not allowed for this option")
         else:
             components.append(value)
-    return AppOrComponentSelector(select_all, apps, components)
+    try:
+        return AppOrComponentSelector(
+            select_all,
+            apps,
+            components,
+        )
+    except ValueError as e:
+        raise click.BadParameter(str(e))
 
 
 def _app_or_component_selector(ctx, param, this_value):
     if any([val.startswith("-") for val in this_value]):
         raise click.BadParameter("requires a component name or keyword 'all'")
 
-    # check if 'app:' syntax has been used and translate input values to apps/components dictionary
-    this_value = _translate_to_obj(this_value)
+    # check if 'app:' syntax or "/dependency" syntax has been used and
+    # translate input values to apps/components dictionary
+    this_value = _translate_to_obj(this_value, param.name)
 
     opposite_option = {
         "remove_resources": "no_remove_resources",
@@ -415,11 +427,12 @@ def _app_or_component_selector(ctx, param, this_value):
             )
 
     # validate that the same component was not used in opposing options
-    for component in this_value.components:
-        if component in other_value.components:
+    # Resolution of wildcard specifiers is handled later
+    for component in this_value.flattened_components:
+        if component in other_value.flattened_components:
             raise click.BadParameter(
-                f"component '{component}' cannot be specified on both this option"
-                f" and its opposite '{other_param_name}'"
+                f"component '{component}' cannot be specified on both this "
+                f"option and its opposite '{other_param_name}'"
             )
 
     # set default value for --remove-resources to 'all' if option was unspecified
@@ -569,7 +582,9 @@ _process_options = _app_source_options + [
         help=(
             "Remove dependencies/optionalDependencies on ClowdApp configs "
             "for specific components or apps. Prefix the app name with "
-            "'app:', otherwise specify the component name. (default: none)"
+            "'app:', otherwise specify the component name. (default: none). "
+            "Specific dependencies can be specified with a slash delimiter. "
+            "E.g. mycomponent/rbac"
         ),
         type=str,
         multiple=True,
@@ -580,7 +595,9 @@ _process_options = _app_source_options + [
         help=(
             "Don't remove dependencies/optionalDependencies on ClowdApp configs "
             "for specific components or apps. Prefix the app name with "
-            "'app:', otherwise specify the component name. (default: all)"
+            "'app:', otherwise specify the component name. (default: all). "
+            "Specific dependencies can be specified with a slash delimiter. "
+            "E.g. mycomponent/rbac"
         ),
         type=str,
         multiple=True,

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -979,7 +979,7 @@ class TemplateProcessor:
             processed_component = self.processed_components[component_name]
 
             skip_further_processing = self._component_skip_check(component_name, dependency_chain)
-            if not skip_further_processing:
+            if not skip_further_processing and not processed_component.should_apply:
                 log.info(
                     "previously skipped component '%s' is a dependency.  Adding.", component_name
                 )

--- a/tests/test_bonfire.py
+++ b/tests/test_bonfire.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 from unittest.mock import ANY
 
+import click
 import pytest
 from click.testing import CliRunner
 
@@ -379,3 +380,97 @@ def test_remove_resources_all(mocker):
     assert kwargs["no_remove_resources"].select_all is True
     assert kwargs["remove_dependencies"].select_all is False
     assert kwargs["no_remove_dependencies"].select_all is True
+
+
+def test_remove_dependencies_wildcard(mocker):
+    get_return_args = mocker.patch("bonfire.bonfire._get_return_args")
+
+    runner = CliRunner()
+    result = runner.invoke(bonfire.test, ["process", "some-app", "--remove-dependencies", "hello"])
+    assert result.exit_code == 0
+
+    call = get_return_args.call_args
+    assert call
+    _, kwargs = call
+    remove_deps = kwargs["remove_dependencies"]
+    keep_deps = kwargs["no_remove_dependencies"]
+    assert remove_deps.components == {"hello": {"*"}}
+    assert keep_deps.components == {}
+
+
+def test_remove_dependencies_specific(mocker):
+    get_return_args = mocker.patch("bonfire.bonfire._get_return_args")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        bonfire.test,
+        [
+            "process",
+            "some-app",
+            "--remove-dependencies",
+            "hello/world",
+            "--remove-dependencies",
+            "foo/bar",
+        ],
+    )
+    assert result.exit_code == 0
+
+    call = get_return_args.call_args
+    assert call
+    _, kwargs = call
+    remove_deps = kwargs["remove_dependencies"]
+    assert remove_deps.components == {"hello": {"world"}, "foo": {"bar"}}
+
+
+def test_remove_dependencies_disallows_nested_slashes():
+    runner = CliRunner()
+    with pytest.raises(click.BadParameter) as e:
+        runner.invoke(
+            bonfire.test,
+            ["process", "some-app", "--remove-dependencies", "hello/world/foo"],
+            catch_exceptions=False,
+            standalone_mode=False,
+        )
+    assert "Only one / is allowed" in e.value.message
+
+
+def test_remove_dependencies_disallows_general_and_specific():
+    runner = CliRunner()
+    with pytest.raises(click.BadParameter) as e:
+        runner.invoke(
+            bonfire.test,
+            [
+                "process",
+                "some-app",
+                "--remove-dependencies",
+                "hello/world",
+                "--remove-dependencies",
+                "hello",
+            ],
+            catch_exceptions=False,
+            standalone_mode=False,
+        )
+    msg = (
+        "Specifying both an entire component and specific dependencies of "
+        "that component is not allowed"
+    )
+    assert msg in e.value.message
+
+
+def test_disallows_dependency_specification_conflicts():
+    runner = CliRunner()
+    with pytest.raises(click.BadParameter) as e:
+        runner.invoke(
+            bonfire.test,
+            [
+                "process",
+                "some-app",
+                "--remove-dependencies",
+                "hello/world",
+                "--no-remove-dependencies",
+                "hello/world",
+            ],
+            catch_exceptions=False,
+            standalone_mode=False,
+        )
+    assert "cannot be specified on both this option and its opposite" in e.value.message

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -529,6 +529,7 @@ def test_mixed_deps(mock_repo_file, optional_deps_method, expected):
             [
                 "app5-component3",
                 "app5-component2",
+                "app1-component1"
             ],
         ),
         (
@@ -546,6 +547,8 @@ def test_mixed_deps_with_component_filter(mock_repo_file, optional_deps_method, 
     app5-component1 has 'app5-component2' listed under 'dependencies'
     app5-component1 has 'app5-component3' listed under 'optionalDependencies'
 
+    app5-component2 has 'app1-component1' listed under 'optionalDependencies'
+
     app5-component3 has 'app5-component2' listed under 'optionalDependencies'
 
     bonfire is run with '--component app5-component3'
@@ -555,15 +558,18 @@ def test_mixed_deps_with_component_filter(mock_repo_file, optional_deps_method, 
     """
     add_template(
         mock_repo_file,
+        "app1-component1",
+    )
+    add_template(
+        mock_repo_file,
         "app5-component1",
         deps=["app5-component2"],
         optional_deps=["app5-component3"],
     )
-    add_template(mock_repo_file, "app5-component2")
+    add_template(mock_repo_file, "app5-component2", optional_deps=["app1-component1"])
     add_template(
         mock_repo_file,
         "app5-component3",
-        deps=[],
         optional_deps=["app5-component2"],
     )
 

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,8 +1,14 @@
 import uuid
 
+import click
 import pytest
 
-from bonfire.processor import TemplateProcessor, _should_remove
+from bonfire.processor import (
+    TemplateProcessor,
+    _should_alter,
+    _resolve_dependency_overrides,
+    _alter_dependency_config,
+)
 from bonfire.utils import RepoFile, AppOrComponentSelector
 
 
@@ -344,10 +350,10 @@ def test_required_deps(mock_repo_file, optional_deps_method, expected):
 def test_transitive_dependency_resolution_with_components(mock_repo_file):
     add_template(mock_repo_file, "app1-component1", deps=["app2-component1"])
     add_template(mock_repo_file, "app2-component1", deps=["app3-component1"])
-    add_template(mock_repo_file, "app3-component1", deps=[])
+    add_template(mock_repo_file, "app3-component1")
     add_template(mock_repo_file, "app1-component2", deps=["app2-component2"])
     add_template(mock_repo_file, "app2-component2", deps=["app3-component2"])
-    add_template(mock_repo_file, "app3-component2", deps=[])
+    add_template(mock_repo_file, "app3-component2")
 
     processor = get_processor(get_apps_config())
     processor.optional_deps_method = "all"
@@ -355,6 +361,41 @@ def test_transitive_dependency_resolution_with_components(mock_repo_file):
     processor.component_filter = ("app1-component1",)
     processed = processor.process()
     expected = ["app1-component1", "app2-component1", "app3-component1"]
+    assert_clowdapps(processed["items"], expected)
+
+
+def test_reprocesses_dependency(mock_repo_file):
+    add_template(mock_repo_file, "app1-component1")
+    add_template(mock_repo_file, "app1-component2", deps=["app1-component1"])
+
+    processor = get_processor(get_apps_config())
+    processor.requested_app_names = ["app1"]
+    processor.component_filter = ("app1-component2",)
+    processed = processor.process()
+    expected = ["app1-component2", "app1-component1"]
+    assert_clowdapps(processed["items"], expected)
+
+
+def test_unlisted_component_does_not_remove_dependency_from_listed_component(mock_repo_file):
+    """
+    The graph looks like
+        a1-c1 -> a2-c2 -> a3-c2
+        a1-c2 -> a2-c2 -> a3-c3
+    And we request component a1-c2.  This test is meant to ensure that a2-c2 and its
+    dependencies are included even though it is also a dependency of a component that doesn't
+    match the filter (a1-c1).
+    """
+    add_template(mock_repo_file, "app1-component1", deps=["app2-component2"])
+    add_template(mock_repo_file, "app2-component2", deps=["app3-component2"])
+    add_template(mock_repo_file, "app3-component2")
+    add_template(mock_repo_file, "app1-component2", deps=["app2-component2"])
+
+    processor = get_processor(get_apps_config())
+    processor.optional_deps_method = "all"
+    processor.requested_app_names = ["app1"]
+    processor.component_filter = ("app1-component2",)
+    processed = processor.process()
+    expected = ["app1-component2", "app2-component2", "app3-component2"]
     assert_clowdapps(processed["items"], expected)
 
 
@@ -530,6 +571,31 @@ def test_mixed_deps_two_apps(mock_repo_file, optional_deps_method, expected):
     assert_clowdapps(processed["items"], expected)
 
 
+def test_filtered_deps(mock_repo_file):
+    expected = ["app1-component1", "app2-component1", "app4-component1", "app1-component2"]
+    add_template(
+        mock_repo_file,
+        "app1-component1",
+        deps=["app2-component1", "app2-component2"],
+        optional_deps=["app3-component1"],
+    )
+    add_template(mock_repo_file, "app1-component2")
+    add_template(mock_repo_file, "app2-component1", optional_deps=["app4-component1"])
+    add_template(mock_repo_file, "app2-component2", optional_deps=["app4-component2"])
+    add_template(mock_repo_file, "app4-component1")
+    add_template(mock_repo_file, "app4-component2")
+
+    processor = get_processor(get_apps_config())
+    processor.requested_app_names = ["app1"]
+    processor.optional_deps_method = "all"
+    processor.remove_dependencies = AppOrComponentSelector(False, "app1", ["app1-component1"])
+    processor.no_remove_dependencies = AppOrComponentSelector(
+        False, "app1", ["app1-component1/app2-component1"]
+    )
+    processed = processor.process()
+    assert_clowdapps(processed["items"], expected)
+
+
 # Testing --no-remove-resources/dependency "app:" syntax
 def test_should_remove_remove_for_none_no_exceptions():
     # --no-remove-resources all --no-remove-resources component1 --no-remove-resources app:app1
@@ -538,9 +604,23 @@ def test_should_remove_remove_for_none_no_exceptions():
         select_all=True, components=["component1"], apps=["app1"]
     )
 
-    assert _should_remove(remove_resources, no_remove_resources, "app2", "component2") is False
-    assert _should_remove(remove_resources, no_remove_resources, "app2", "component1") is False
-    assert _should_remove(remove_resources, no_remove_resources, "app1", "whatever") is False
+    mutually_exclusive = True
+    assert (
+        _should_alter(
+            remove_resources, no_remove_resources, "app2", "component2", mutually_exclusive
+        )
+        is False
+    )
+    assert (
+        _should_alter(
+            remove_resources, no_remove_resources, "app2", "component1", mutually_exclusive
+        )
+        is False
+    )
+    assert (
+        _should_alter(remove_resources, no_remove_resources, "app1", "whatever", mutually_exclusive)
+        is False
+    )
 
 
 def test_should_remove_remove_for_all_no_exceptions():
@@ -550,41 +630,59 @@ def test_should_remove_remove_for_all_no_exceptions():
     )
     no_remove_resources = AppOrComponentSelector(select_all=False, components=[], apps=[])
 
-    assert _should_remove(remove_resources, no_remove_resources, "app2", "component2") is True
-    assert _should_remove(remove_resources, no_remove_resources, "app2", "component1") is True
-    assert _should_remove(remove_resources, no_remove_resources, "app1", "whatever") is True
+    mutually_exclusive = True
+    assert (
+        _should_alter(
+            remove_resources, no_remove_resources, "app2", "component2", mutually_exclusive
+        )
+        is True
+    )
+    assert (
+        _should_alter(
+            remove_resources, no_remove_resources, "app2", "component1", mutually_exclusive
+        )
+        is True
+    )
+    assert (
+        _should_alter(remove_resources, no_remove_resources, "app1", "whatever", mutually_exclusive)
+        is True
+    )
 
 
 def test_should_remove_remove_option_select_all():
     # --remove-resources all --no-remove-resources component1
+    mutually_exclusive = True
     assert (
-        _should_remove(
+        _should_alter(
             AppOrComponentSelector(select_all=True, components=[], apps=[]),
             AppOrComponentSelector(select_all=False, components=["component1"], apps=[]),
             "app2",
             "component1",
+            mutually_exclusive,
         )
         is False
     )
 
     # --remove-resources all --no-remove-resources app:app1
     assert (
-        _should_remove(
+        _should_alter(
             AppOrComponentSelector(select_all=True, components=[], apps=[]),
             AppOrComponentSelector(select_all=False, components=[], apps=["app1"]),
             "app1",
             "component1",
+            mutually_exclusive,
         )
         is False
     )
 
     # --remove-resources all
     assert (
-        _should_remove(
+        _should_alter(
             AppOrComponentSelector(select_all=True, components=[], apps=[]),
             AppOrComponentSelector(select_all=False, components=[], apps=[]),
             "app1",
             "component2",
+            mutually_exclusive,
         )
         is True
     )
@@ -592,78 +690,86 @@ def test_should_remove_remove_option_select_all():
 
 def test_should_remove_no_remove_option_select_all():
     # --remove-resources component1 --no-remove-resources all
+    mutually_exclusive = True
     assert (
-        _should_remove(
+        _should_alter(
             AppOrComponentSelector(select_all=False, components=["component1"], apps=[]),
             AppOrComponentSelector(select_all=True, components=[], apps=[]),
             "app1",
             "component1",
+            mutually_exclusive,
         )
         is True
     )
 
     # --remove-resources app:app1 --no-remove-resources all
     assert (
-        _should_remove(
+        _should_alter(
             AppOrComponentSelector(select_all=False, components=[], apps=["app1"]),
             AppOrComponentSelector(select_all=True, components=[], apps=[]),
             "app1",
             "component1",
+            mutually_exclusive,
         )
         is True
     )
 
     # --remove-resources component1 --remove-resources app:app1 --no-remove-resources all
     assert (
-        _should_remove(
+        _should_alter(
             AppOrComponentSelector(select_all=False, components=["component1"], apps=["app1"]),
             AppOrComponentSelector(select_all=True, components=[], apps=[]),
             "app1",
             "component1",
+            mutually_exclusive,
         )
         is True
     )
 
     # --remove-resources component1 --remove-resources app:app2 --no-remove-resources all
     assert (
-        _should_remove(
+        _should_alter(
             AppOrComponentSelector(select_all=False, components=["component1"], apps=["app1"]),
             AppOrComponentSelector(select_all=True, components=[], apps=[]),
             "app2",
             "component1",
+            mutually_exclusive,
         )
         is True
     )
 
     # --remove-resources component2 --remove-resources app:app1 --no-remove-resources all
     assert (
-        _should_remove(
+        _should_alter(
             AppOrComponentSelector(select_all=False, components=["component1"], apps=["app1"]),
             AppOrComponentSelector(select_all=True, components=[], apps=[]),
             "app1",
             "component2",
+            mutually_exclusive,
         )
         is True
     )
 
     # --remove-resources component2 --remove-resources app:app2 --no-remove-resources all
     assert (
-        _should_remove(
+        _should_alter(
             AppOrComponentSelector(select_all=False, components=["component1"], apps=["app1"]),
             AppOrComponentSelector(select_all=True, components=[], apps=[]),
             "app2",
             "component2",
+            mutually_exclusive,
         )
         is False
     )
 
     assert (
         # --no-remove-resources all
-        _should_remove(
+        _should_alter(
             AppOrComponentSelector(select_all=False, components=[], apps=[]),
             AppOrComponentSelector(select_all=True, components=[], apps=[]),
             "app1",
             "component1",
+            mutually_exclusive,
         )
         is False
     )
@@ -674,16 +780,24 @@ def test_should_remove_component_overrides_app(default):
     # --no-remove-resources app:app1 --remove-resources component1
     remove_resources = AppOrComponentSelector(select_all=False, components=["component2"], apps=[])
     no_remove_resources = AppOrComponentSelector(select_all=False, components=[], apps=["app1"])
+    mutually_exclusive = True
 
     assert (
-        _should_remove(remove_resources, no_remove_resources, "app1", "component1", default)
+        _should_alter(
+            remove_resources, no_remove_resources, "app1", "component1", mutually_exclusive, default
+        )
         is False
     )
     assert (
-        _should_remove(remove_resources, no_remove_resources, "app1", "component2", default) is True
+        _should_alter(
+            remove_resources, no_remove_resources, "app1", "component2", mutually_exclusive, default
+        )
+        is True
     )
     assert (
-        _should_remove(remove_resources, no_remove_resources, "anything", "else", default)
+        _should_alter(
+            remove_resources, no_remove_resources, "anything", "else", mutually_exclusive, default
+        )
         is default
     )
 
@@ -699,21 +813,35 @@ def test_should_remove_component_app_combos(default):
         select_all=False, components=["component2"], apps=["app2"]
     )
 
+    mutually_exclusive = True
     assert (
-        _should_remove(remove_resources, no_remove_resources, "app2", "component1", default) is True
+        _should_alter(
+            remove_resources, no_remove_resources, "app2", "component1", mutually_exclusive, default
+        )
+        is True
     )
     assert (
-        _should_remove(remove_resources, no_remove_resources, "app1", "anything", default) is True
+        _should_alter(
+            remove_resources, no_remove_resources, "app1", "anything", mutually_exclusive, default
+        )
+        is True
     )
     assert (
-        _should_remove(remove_resources, no_remove_resources, "app1", "component2", default)
+        _should_alter(
+            remove_resources, no_remove_resources, "app1", "component2", mutually_exclusive, default
+        )
         is False
     )
     assert (
-        _should_remove(remove_resources, no_remove_resources, "app2", "anything", default) is False
+        _should_alter(
+            remove_resources, no_remove_resources, "app2", "anything", mutually_exclusive, default
+        )
+        is False
     )
     assert (
-        _should_remove(remove_resources, no_remove_resources, "anything", "else", default)
+        _should_alter(
+            remove_resources, no_remove_resources, "anything", "else", mutually_exclusive, default
+        )
         is default
     )
 
@@ -983,3 +1111,91 @@ def test_parse_exclude_components():
     input_tuple = ("component1", "component2")
     result = TemplateProcessor._parse_exclude_components(input_tuple)
     assert result == ["component1", "component2"]
+
+
+@pytest.mark.parametrize(
+    "keep,remove,expected",
+    [
+        ({"a"}, {"b"}, {"a", "c"}),
+        ({"*"}, {"b"}, {"a", "c"}),
+        ({None}, {"b"}, {"a", "c"}),
+        ({"a"}, {None}, {"a", "b", "c"}),
+        ({"*"}, {None}, {"a", "b", "c"}),
+        ({None}, {None}, {"a", "b", "c"}),
+        ({"a"}, {"*"}, {"a"}),
+        # Combination ["*"] and ["*"] is an error and is tested elsewhere
+        ({None}, {"*"}, set()),
+    ],
+)
+def test_dependency_resolution(keep, remove, expected):
+    dependencies = {"a", "b", "c"}
+    result = _resolve_dependency_overrides(dependencies, keep, remove)
+    # Thanks https://stackoverflow.com/a/61494686/6124862
+    lacks = expected.difference(result)
+    extra = result.difference(expected)
+    message = f"Lacks elements {lacks} " if lacks else ""
+    message += f"Extra elements {extra}" if extra else ""
+    assert not message
+
+
+def test_dependency_resolution_validates_no_common_items():
+    dependencies = {"a", "b", "c"}
+    keep = {"a"}
+    remove = {"a"}
+    with pytest.raises(click.ClickException) as e:
+        _resolve_dependency_overrides(dependencies, keep, remove)
+    assert "Cannot resolve dependency list" in e.value.message
+
+
+def test_dependency_resolution_validates_no_wildcard():
+    dependencies = {"a", "b", "c"}
+    keep = {"*"}
+    remove = {"*"}
+    with pytest.raises(click.ClickException) as e:
+        _resolve_dependency_overrides(dependencies, keep, remove)
+    assert "Cannot resolve dependency list" in e.value.message
+
+
+def test_dependency_resolution_validates_wildcard_only_item():
+    dependencies = {"a", "b", "c"}
+    keep = {"*", "b"}
+    remove = {"a"}
+    with pytest.raises(click.ClickException) as e:
+        _resolve_dependency_overrides(dependencies, keep, remove)
+    assert "Invalid dependency modification specifier" in e.value.message
+
+
+def test_dependency_resolution_validates_not_none_not_empty():
+    dependencies = {"a", "b", "c"}
+    keep = set()
+    remove = {"a"}
+    with pytest.raises(click.ClickException) as e:
+        _resolve_dependency_overrides(dependencies, keep, remove)
+    assert "cannot be None or an empty list" in e.value.message
+
+    keep = None
+    with pytest.raises(click.ClickException) as e:
+        _resolve_dependency_overrides(dependencies, keep, remove)
+    assert "cannot be None or an empty list" in e.value.message
+
+
+def test_dependency_resolution_validates_dependency_presence(mock_repo_file):
+    items = [
+        {
+            "kind": "ClowdApp",
+            "metadata": {"name": "hello"},
+            "spec": {"dependencies": ["a", "b"], "optionalDependencies": ["c"]},
+        }
+    ]
+
+    keep = {None}
+    remove = {"x"}
+    with pytest.raises(click.ClickException) as e:
+        _alter_dependency_config(items, "hello", keep, remove)
+    assert "not present in dependencies" in e.value.message
+
+    keep = {"y"}
+    remove = {None}
+    with pytest.raises(click.ClickException) as e:
+        _alter_dependency_config(items, "hello", keep, remove)
+    assert "not present in dependencies" in e.value.message

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -526,11 +526,7 @@ def test_mixed_deps(mock_repo_file, optional_deps_method, expected):
     [
         (
             "all",
-            [
-                "app5-component3",
-                "app5-component2",
-                "app1-component1"
-            ],
+            ["app5-component3", "app5-component2", "app1-component1"],
         ),
         (
             "hybrid",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,7 @@ from bonfire.utils import (
     check_pypi,
     PYPI_URL,
 )
-from bonfire.utils import check_url_connection, FatalError
+from bonfire.utils import check_url_connection, FatalError, AppOrComponentSelector
 
 
 @pytest.mark.parametrize(
@@ -161,3 +161,9 @@ def test_check_version_invalid_response(requests_mock, mocker):
 
     log_mock.error.assert_called_once()
     assert "error fetching version from pypi" in log_mock.error.call_args_list[0].args[0]
+
+
+def test_selector_defaults():
+    selector = AppOrComponentSelector(False, None, ["hello/world"])
+    assert selector.flattened_components == ["hello/world"]
+    assert selector.components == {"hello": {"world"}}


### PR DESCRIPTION
In some cases, uses may want to be selective about dependency removal. For example, if some dependencies are being mocked during application testing (e.g. with WireMock), the user might still wish to retain other dependencies.

This patch changes the `--no-remove-dependency` and `--remove-dependency` options to accept a slash after a component name followed by a dependency.  If no slash follows, the component name, all dependencies will be operated on.

Obviously this creates a resolution problem if the user provides something like` --remove-dependencies foo --no-remove-dependencies foo/bar`.  The code follows two rules: "specific beats general" and "keep by default".  So in the example, the result would be the removal of all dependencies except for foo/bar.  The resolution is handled through set operations.  Or in the example `--remove-dependencies component/b --keep-dependencies component/c` with an application that had the dependencies a, b, and c, the result would be the retention of the dependencies a and c.

This patch also adds substantial validation to catch cases that may be technically resolvable but are more ambiguous.  For example, `--remove-dependencies foo --remove-dependencies foo/bar`.  While this case is resolvable without too much thought, I didn't want to introduce additional complexity into what is already a fairly complex process.