### PR TITLE
Support for specifying team name upon reserving a namespace

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -1243,9 +1243,7 @@ def _check_and_reserve_namespace(name, requester, duration, pool, timeout, local
 
     team = ""
     if pool == "ai-development":
-        log.info("------------------------------- This pool exists! -------------------------------------")
-        team = input("What team are you on? ")
-        log.info(f"user is on team: {team}")
+        team = input("You are about to reserve a namespace from the 'ai-development' pool; What team are you on? ")
 
     if pool not in get_namespace_pools():
         _error(f"namespace pool '{pool}' does not exist on this cluster")

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -1243,7 +1243,9 @@ def _check_and_reserve_namespace(name, requester, duration, pool, timeout, local
 
     team = ""
     if pool in conf.AI_SPECIFIC_POOLS:
-        team = input("\033[1;32mYou are about to reserve a namespace from the 'ai-development' pool - What team are you on?\033[0m ")
+        team = input(
+            "\033[1;32mYou are about to reserve a namespace from the 'ai-development' pool - What team are you on?\033[0m "
+        )
 
     if pool not in get_namespace_pools():
         _error(f"namespace pool '{pool}' does not exist on this cluster")

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -1177,7 +1177,16 @@ def _cmd_process(
 
 
 def _get_namespace(
-    requested_ns_name, name, requester, team, duration, pool, timeout, local, force, using_current=False
+    requested_ns_name,
+    name,
+    requester,
+    team,
+    duration,
+    pool,
+    timeout,
+    local,
+    force,
+    using_current=False
 ):
     if not has_ns_operator():
         if requested_ns_name:
@@ -1197,7 +1206,9 @@ def _get_namespace(
                 "current namespace could not be used (not reserved,"
                 " expired, or not owned), reserving a new one",
             )
-        ns = _check_and_reserve_namespace(name, requester, team, duration, pool, timeout, local, force)
+        ns = _check_and_reserve_namespace(
+            name, requester, team, duration, pool, timeout, local, force
+        )
         reserved_new_ns = True
 
     return ns.name, reserved_new_ns
@@ -1246,13 +1257,6 @@ def _check_and_use_namespace(requested_ns_name, using_current, requester):
 def _check_and_reserve_namespace(name, requester, team, duration, pool, timeout, local, force):
     if not has_ns_operator():
         _error(f"{NO_RESERVATION_SYS}")
-
-    # PLACEHOLDER: remove
-    #team = ""
-    #if pool in conf.AI_SPECIFIC_POOLS:
-    #    team = input(
-    #        "\033[1;32mYou are about to reserve a namespace from the 'ai-development' pool - What team are you on?\033[0m "
-    #    )
 
     if pool not in get_namespace_pools():
         _error(f"namespace pool '{pool}' does not exist on this cluster")
@@ -1544,7 +1548,9 @@ def _cmd_deploy_clowdenv(
     if not has_clowder():
         _error("cluster does not have clowder operator installed")
 
-    namespace, _ = _get_namespace(namespace, name, requester, team, duration, pool, timeout, local, force)
+    namespace, _ = _get_namespace(
+        namespace, name, requester, team, duration, pool, timeout, local, force
+    )
 
     if import_secrets:
         import_secrets_from_dir(secrets_dir)
@@ -1659,7 +1665,9 @@ def _cmd_deploy_iqe_cji(
     if not has_clowder():
         _error("cluster does not have clowder operator installed")
 
-    namespace, _ = _get_namespace(namespace, name, requester, team, duration, pool, timeout, local, force)
+    namespace, _ = _get_namespace(
+        namespace, name, requester, team, duration, pool, timeout, local, force
+    )
 
     cji_config = process_iqe_cji(
         clowd_app_name,

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -1242,7 +1242,7 @@ def _check_and_reserve_namespace(name, requester, duration, pool, timeout, local
         _error(f"{NO_RESERVATION_SYS}")
 
     team = ""
-    if pool == "ai-development":
+    if pool in conf.AI_SPECIFIC_POOLS:
         team = input("\033[1;32mYou are about to reserve a namespace from the 'ai-development' pool - What team are you on?\033[0m ")
 
     if pool not in get_namespace_pools():

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -1533,6 +1533,7 @@ def _cmd_deploy_clowdenv(
     configmaps_dir,
     name,
     requester,
+    team,
     duration,
     local,
     pool,

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -241,7 +241,7 @@ _ns_reserve_options = [
         "--team",
         type=str,
         default="",
-        help="Team name associated with requester for",
+        help="Team name associated with reservation requester",
     ),
     click.option(
         "--duration",

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -1241,6 +1241,12 @@ def _check_and_reserve_namespace(name, requester, duration, pool, timeout, local
     if not has_ns_operator():
         _error(f"{NO_RESERVATION_SYS}")
 
+    team = ""
+    if pool == "ai-development":
+        log.info("------------------------------- This pool exists! -------------------------------------")
+        team = input("What team are you on? ")
+        log.info(f"user is on team: {team}")
+
     if pool not in get_namespace_pools():
         _error(f"namespace pool '{pool}' does not exist on this cluster")
 
@@ -1259,7 +1265,7 @@ def _check_and_reserve_namespace(name, requester, duration, pool, timeout, local
             " have been reserved"
         )
 
-    return reserve_namespace(name, requester, duration, pool, timeout, local)
+    return reserve_namespace(name, requester, duration, pool, timeout, local, team)
 
 
 def _deploy_err_handler(err, no_release_on_fail, reserved_new_ns, reserve, ns):

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -240,7 +240,7 @@ _ns_reserve_options = [
     click.option(
         "--team",
         type=str,
-        default=None,
+        default="",
         help="Team name associated with requester for",
     ),
     click.option(

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -1243,7 +1243,7 @@ def _check_and_reserve_namespace(name, requester, duration, pool, timeout, local
 
     team = ""
     if pool == "ai-development":
-        team = input("You are about to reserve a namespace from the 'ai-development' pool; What team are you on? ")
+        team = input("\033[1;32mYou are about to reserve a namespace from the 'ai-development' pool - What team are you on?\033[0m ")
 
     if pool not in get_namespace_pools():
         _error(f"namespace pool '{pool}' does not exist on this cluster")

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -1642,6 +1642,7 @@ def _cmd_deploy_iqe_cji(
     plugins,
     name,
     requester,
+    team,
     duration,
     local,
     selenium,

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -1186,7 +1186,7 @@ def _get_namespace(
     timeout,
     local,
     force,
-    using_current=False
+    using_current=False,
 ):
     if not has_ns_operator():
         if requested_ns_name:

--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -22,7 +22,6 @@ DEFAULT_SECRETS_DIR = get_config_path().joinpath("secrets")
 DEFAULT_CONFIGMAPS_DIR = get_config_path().joinpath("configmaps")
 
 DEFAULT_NAMESPACE_POOL = "default"
-AI_SPECIFIC_POOLS = ["ai-development"]
 
 DEFAULT_CLOWDENV_TEMPLATE = importlib_resources.files("bonfire").joinpath(
     "resources/local-cluster-clowdenvironment.yaml"

--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -22,6 +22,7 @@ DEFAULT_SECRETS_DIR = get_config_path().joinpath("secrets")
 DEFAULT_CONFIGMAPS_DIR = get_config_path().joinpath("configmaps")
 
 DEFAULT_NAMESPACE_POOL = "default"
+AI_SPECIFIC_POOLS = ["ai-development"]
 
 DEFAULT_CLOWDENV_TEMPLATE = importlib_resources.files("bonfire").joinpath(
     "resources/local-cluster-clowdenvironment.yaml"

--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -281,10 +281,7 @@ def reserve_namespace(name, requester, duration, pool, timeout, local=True, team
     if res:
         raise FatalError(f"Reservation with name {name} already exists")
 
-    log.info(f"------ ANOTHER CHECK FOR TEAMMMMM: {team} -------")
     res_config = process_reservation(name, requester, duration, pool, local=local, team=team)
-
-    log.info(f"res_config: {res_config}")
 
     log.debug("processed reservation:\n%s", res_config)
 

--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -275,13 +275,16 @@ def get_namespaces(available=False, mine=False):
     return ephemeral_namespaces
 
 
-def reserve_namespace(name, requester, duration, pool, timeout, local=True):
+def reserve_namespace(name, requester, duration, pool, timeout, local=True, team=None):
     res = get_reservation(name)
     # Name should be unique on reservation creation.
     if res:
         raise FatalError(f"Reservation with name {name} already exists")
 
-    res_config = process_reservation(name, requester, duration, pool, local=local)
+    log.info(f"------ ANOTHER CHECK FOR TEAMMMMM: {team} -------")
+    res_config = process_reservation(name, requester, duration, pool, local=local, team=team)
+
+    log.info(f"res_config: {res_config}")
 
     log.debug("processed reservation:\n%s", res_config)
 

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -380,7 +380,7 @@ def process_iqe_cji(
 
 
 def process_reservation(
-        name, requester, duration, pool=None, template_path=None, local=True, team=None
+    name, requester, duration, pool=None, template_path=None, local=True, team=None
 ):
     log.info("processing namespace reservation")
     template_path = Path(template_path if template_path else conf.DEFAULT_RESERVATION_TEMPLATE)

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -379,7 +379,9 @@ def process_iqe_cji(
     return processed_template
 
 
-def process_reservation(name, requester, duration, pool=None, template_path=None, local=True, team=None):
+def process_reservation(
+        name, requester, duration, pool=None, template_path=None, local=True, team=None
+):
     log.info("processing namespace reservation")
     template_path = Path(template_path if template_path else conf.DEFAULT_RESERVATION_TEMPLATE)
 

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -23,7 +23,6 @@ log = logging.getLogger(__name__)
 
 
 def _process_template(*args, **kwargs):
-    log.info(f"------- ARGSSSSS: {args} --------")
     # run process_template with prettier error handling
     try:
         processed_template = process_template(*args, **kwargs)
@@ -382,11 +381,6 @@ def process_iqe_cji(
 
 def process_reservation(name, requester, duration, pool=None, template_path=None, local=True, team=None):
     log.info("processing namespace reservation")
-
-    log.info(f"process_reservation func: team name is: {team}")
-
-    log.info(f"----- TEMPLATE PATHHHH: {template_path} -----")
-
     template_path = Path(template_path if template_path else conf.DEFAULT_RESERVATION_TEMPLATE)
 
     if not template_path.exists():
@@ -396,12 +390,9 @@ def process_reservation(name, requester, duration, pool=None, template_path=None
         template_data = yaml.safe_load(fp)
 
     params = dict()
-    log.info(f"------- params: {params} ---------")
 
     params["NAME"] = name if name else f"bonfire-reservation-{str(uuid.uuid4()).split('-')[0]}"
-    log.info(f"------- params: {params} ---------")
     params["DURATION"] = duration
-    log.info(f"------- params: {params} ---------")
 
     if requester is None:
         try:
@@ -411,12 +402,8 @@ def process_reservation(name, requester, duration, pool=None, template_path=None
             requester = "bonfire"
 
     params["REQUESTER"] = requester
-    log.info(f"------- params: {params} ---------")
     params["TEAM"] = team
-    log.info(f"------- params: {params} ---------")
-    log.info(f"----- TEAM: {team} ----------")
     params["POOL"] = pool if pool else "default"
-    log.info(f"------- params: {params} ---------")
 
     processed_template = _process_template(template_data, params=params, local=local)
 

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -402,7 +402,7 @@ def process_reservation(
             requester = "bonfire"
 
     params["REQUESTER"] = requester
-    params["TEAM"] = team
+    params["TEAM"] = team or ""
     params["POOL"] = pool if pool else "default"
 
     processed_template = _process_template(template_data, params=params, local=local)

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -23,6 +23,7 @@ log = logging.getLogger(__name__)
 
 
 def _process_template(*args, **kwargs):
+    log.info(f"------- ARGSSSSS: {args} --------")
     # run process_template with prettier error handling
     try:
         processed_template = process_template(*args, **kwargs)
@@ -379,8 +380,12 @@ def process_iqe_cji(
     return processed_template
 
 
-def process_reservation(name, requester, duration, pool=None, template_path=None, local=True):
+def process_reservation(name, requester, duration, pool=None, template_path=None, local=True, team=None):
     log.info("processing namespace reservation")
+
+    log.info(f"process_reservation func: team name is: {team}")
+
+    log.info(f"----- TEMPLATE PATHHHH: {template_path} -----")
 
     template_path = Path(template_path if template_path else conf.DEFAULT_RESERVATION_TEMPLATE)
 
@@ -391,9 +396,12 @@ def process_reservation(name, requester, duration, pool=None, template_path=None
         template_data = yaml.safe_load(fp)
 
     params = dict()
+    log.info(f"------- params: {params} ---------")
 
     params["NAME"] = name if name else f"bonfire-reservation-{str(uuid.uuid4()).split('-')[0]}"
+    log.info(f"------- params: {params} ---------")
     params["DURATION"] = duration
+    log.info(f"------- params: {params} ---------")
 
     if requester is None:
         try:
@@ -403,7 +411,12 @@ def process_reservation(name, requester, duration, pool=None, template_path=None
             requester = "bonfire"
 
     params["REQUESTER"] = requester
+    log.info(f"------- params: {params} ---------")
+    params["TEAM"] = team
+    log.info(f"------- params: {params} ---------")
+    log.info(f"----- TEAM: {team} ----------")
     params["POOL"] = pool if pool else "default"
+    log.info(f"------- params: {params} ---------")
 
     processed_template = _process_template(template_data, params=params, local=local)
 

--- a/bonfire/resources/reservation-template.yaml
+++ b/bonfire/resources/reservation-template.yaml
@@ -13,12 +13,15 @@ objects:
   spec:
     duration: ${DURATION}
     requester: ${REQUESTER}
+    team: ${TEAM}
     pool: ${POOL}
 
 parameters:
 - name: DURATION
   required: true
 - name: REQUESTER
+  required: true
+- name: TEAM
   required: true
 - name: NAME
   required: true

--- a/bonfire/resources/reservation-template.yaml
+++ b/bonfire/resources/reservation-template.yaml
@@ -22,7 +22,7 @@ parameters:
 - name: REQUESTER
   required: true
 - name: TEAM
-  required: true
+  required: false 
 - name: NAME
   required: true
 - name: POOL

--- a/tests/test_bonfire.py
+++ b/tests/test_bonfire.py
@@ -105,11 +105,11 @@ def test_ns_reserve_flag_duration(mocker, caplog, duration: str):
 
     if duration:
         mock_process_reservation.assert_called_once_with(
-            None, "user-3", duration, "default", local=True, team=''
+            None, "user-3", duration, "default", local=True, team=""
         )
     else:
         mock_process_reservation.assert_called_once_with(
-            None, "user-3", "1h", "default", local=True, team=''
+            None, "user-3", "1h", "default", local=True, team=""
         )
 
 

--- a/tests/test_bonfire.py
+++ b/tests/test_bonfire.py
@@ -48,7 +48,9 @@ def test_ns_reserve_flag_name(mocker, caplog, name: str):
     result = runner.invoke(bonfire.namespace, ["reserve", "--name", name])
     print(result.output)
 
-    mock_process_reservation.assert_called_once_with(name, "user-3", "1h", "default", local=True, team="")
+    mock_process_reservation.assert_called_once_with(
+        name, "user-3", "1h", "default", local=True, team=""
+    )
 
 
 @pytest.mark.parametrize(
@@ -75,7 +77,9 @@ def test_ns_reserve_flag_requester(mocker, caplog, requester: str):
     result = runner.invoke(bonfire.namespace, ["reserve", "--requester", requester])
     print(result.output)
 
-    mock_process_reservation.assert_called_once_with(None, requester, "1h", "default", local=True, team="")
+    mock_process_reservation.assert_called_once_with(
+        None, requester, "1h", "default", local=True, team=""
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_bonfire.py
+++ b/tests/test_bonfire.py
@@ -48,7 +48,7 @@ def test_ns_reserve_flag_name(mocker, caplog, name: str):
     result = runner.invoke(bonfire.namespace, ["reserve", "--name", name])
     print(result.output)
 
-    mock_process_reservation.assert_called_once_with(name, "user-3", "1h", "default", local=True)
+    mock_process_reservation.assert_called_once_with(name, "user-3", "1h", "default", local=True, team="")
 
 
 @pytest.mark.parametrize(
@@ -75,7 +75,7 @@ def test_ns_reserve_flag_requester(mocker, caplog, requester: str):
     result = runner.invoke(bonfire.namespace, ["reserve", "--requester", requester])
     print(result.output)
 
-    mock_process_reservation.assert_called_once_with(None, requester, "1h", "default", local=True)
+    mock_process_reservation.assert_called_once_with(None, requester, "1h", "default", local=True, team="")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_bonfire.py
+++ b/tests/test_bonfire.py
@@ -105,11 +105,11 @@ def test_ns_reserve_flag_duration(mocker, caplog, duration: str):
 
     if duration:
         mock_process_reservation.assert_called_once_with(
-            None, "user-3", duration, "default", local=True
+            None, "user-3", duration, "default", local=True, team=''
         )
     else:
         mock_process_reservation.assert_called_once_with(
-            None, "user-3", "1h", "default", local=True
+            None, "user-3", "1h", "default", local=True, team=''
         )
 
 

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1281,7 +1281,6 @@ def test_dependency_resolution_validates_dependency_presence(mock_repo_file):
 
 
 def test_process_reservation_with_team(mocker):
-
     """
     Test that process_reservation correctly handles the team parameter
     """
@@ -1323,8 +1322,7 @@ def test_process_reservation_with_team(mocker):
     # Verify the template was processed with correct parameters
     mock_process_template.assert_called_once()
     call_args = mock_process_template.call_args
-    params = call_args[1]["params"]
- 
+    params = call_args[1]["params"] 
     assert params["NAME"] == "test-reservation"
     assert params["REQUESTER"] == "test-user"
     assert params["DURATION"] == "1h"

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1322,7 +1322,7 @@ def test_process_reservation_with_team(mocker):
     # Verify the template was processed with correct parameters
     mock_process_template.assert_called_once()
     call_args = mock_process_template.call_args
-    params = call_args[1]["params"] 
+    params = call_args[1]["params"]
     assert params["NAME"] == "test-reservation"
     assert params["REQUESTER"] == "test-user"
     assert params["DURATION"] == "1h"

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1281,10 +1281,12 @@ def test_dependency_resolution_validates_dependency_presence(mock_repo_file):
 
 
 def test_process_reservation_with_team(mocker):
+
     """
     Test that process_reservation correctly handles the team parameter
     """
-    from bonfire.processor import process_reservation 
+    from bonfire.processor import process_reservation
+
     # Mock the template processing
     mock_process_template = mocker.patch("bonfire.processor._process_template")
     mock_process_template.return_value = {
@@ -1301,18 +1303,15 @@ def test_process_reservation_with_team(mocker):
                 },
             }
         ]
-    }
- 
+    } 
     # Mock file operations
     mock_path = mocker.patch("bonfire.processor.Path")
     mock_path.return_value.exists.return_value = True
     mock_path.return_value.open.return_value.__enter__.return_value.read.return_value = (
         "mock template"
-    )
- 
+    ) 
     # Mock yaml.safe_load
-    mocker.patch("bonfire.processor.yaml.safe_load", return_value={"mock": "template"})
- 
+    mocker.patch("bonfire.processor.yaml.safe_load", return_value={"mock": "template"}) 
     # Test with team parameter
     result = process_reservation(
         name="test-reservation",
@@ -1320,8 +1319,7 @@ def test_process_reservation_with_team(mocker):
         duration="1h",
         pool="default",
         team="test-team",
-    )
- 
+    ) 
     # Verify the template was processed with correct parameters
     mock_process_template.assert_called_once()
     call_args = mock_process_template.call_args
@@ -1331,7 +1329,7 @@ def test_process_reservation_with_team(mocker):
     assert params["REQUESTER"] == "test-user"
     assert params["DURATION"] == "1h"
     assert params["POOL"] == "default"
-    assert params["TEAM"] == "test-team" 
+    assert params["TEAM"] == "test-team"
 
     assert result == mock_process_template.return_value
 
@@ -1341,6 +1339,7 @@ def test_process_reservation_without_team(mocker):
     Test that process_reservation correctly handles None team parameter
     """
     from bonfire.processor import process_reservation 
+
     # Mock the template processing
     mock_process_template = mocker.patch("bonfire.processor._process_template")
     mock_process_template.return_value = {
@@ -1357,33 +1356,27 @@ def test_process_reservation_without_team(mocker):
                 },
             }
         ]
-    }
- 
+    } 
     # Mock file operations
     mock_path = mocker.patch("bonfire.processor.Path")
     mock_path.return_value.exists.return_value = True
     mock_path.return_value.open.return_value.__enter__.return_value.read.return_value = (
         "mock template"
     )
-
     # Mock yaml.safe_load
-    mocker.patch("bonfire.processor.yaml.safe_load", return_value={"mock": "template"})
- 
+    mocker.patch("bonfire.processor.yaml.safe_load", return_value={"mock": "template"}) 
     # Test without team parameter (should default to None)
     result = process_reservation(
         name="test-reservation", requester="test-user", duration="1h", pool="default"
-    )
- 
+    ) 
     # Verify the template was processed with correct parameters
     mock_process_template.assert_called_once()
     call_args = mock_process_template.call_args
-    params = call_args[1]["params"]
- 
+    params = call_args[1]["params"] 
     assert params["NAME"] == "test-reservation"
     assert params["REQUESTER"] == "test-user"
     assert params["DURATION"] == "1h"
     assert params["POOL"] == "default"
     assert params["TEAM"] is None
-    
 
     assert result == mock_process_template.return_value

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1467,6 +1467,6 @@ def test_process_reservation_without_team(mocker):
     assert params["REQUESTER"] == "test-user"
     assert params["DURATION"] == "1h"
     assert params["POOL"] == "default"
-    assert params["TEAM"] is None
+    assert params["TEAM"] == ""
 
     assert result == mock_process_template.return_value

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1311,7 +1311,7 @@ def test_process_reservation_with_team(mocker):
         "mock template"
     )
     # Mock yaml.safe_load
-    mocker.patch("bonfire.processor.yaml.safe_load", return_value={"mock": "template"}) 
+    mocker.patch("bonfire.processor.yaml.safe_load", return_value={"mock": "template"})
     # Test with team parameter
     result = process_reservation(
         name="test-reservation",
@@ -1338,7 +1338,7 @@ def test_process_reservation_without_team(mocker):
     """
     Test that process_reservation correctly handles None team parameter
     """
-    from bonfire.processor import process_reservation 
+    from bonfire.processor import process_reservation
 
     # Mock the template processing
     mock_process_template = mocker.patch("bonfire.processor._process_template")

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1284,8 +1284,7 @@ def test_process_reservation_with_team(mocker):
     """
     Test that process_reservation correctly handles the team parameter
     """
-    from bonfire.processor import process_reservation
- 
+    from bonfire.processor import process_reservation 
     # Mock the template processing
     mock_process_template = mocker.patch("bonfire.processor._process_template")
     mock_process_template.return_value = {
@@ -1341,8 +1340,7 @@ def test_process_reservation_without_team(mocker):
     """
     Test that process_reservation correctly handles None team parameter
     """
-    from bonfire.processor import process_reservation
- 
+    from bonfire.processor import process_reservation 
     # Mock the template processing
     mock_process_template = mocker.patch("bonfire.processor._process_template")
     mock_process_template.return_value = {

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1278,7 +1278,8 @@ def test_dependency_resolution_validates_dependency_presence(mock_repo_file):
     with pytest.raises(click.ClickException) as e:
         _alter_dependency_config(items, "hello", keep, remove)
     assert "not present in dependencies" in e.value.message
-=======
+
+
 def test_process_reservation_with_team(mocker):
     """
     Test that process_reservation correctly handles the team parameter

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1303,13 +1303,13 @@ def test_process_reservation_with_team(mocker):
                 },
             }
         ]
-    } 
+    }
     # Mock file operations
     mock_path = mocker.patch("bonfire.processor.Path")
     mock_path.return_value.exists.return_value = True
     mock_path.return_value.open.return_value.__enter__.return_value.read.return_value = (
         "mock template"
-    ) 
+    )
     # Mock yaml.safe_load
     mocker.patch("bonfire.processor.yaml.safe_load", return_value={"mock": "template"}) 
     # Test with team parameter
@@ -1319,7 +1319,7 @@ def test_process_reservation_with_team(mocker):
         duration="1h",
         pool="default",
         team="test-team",
-    ) 
+    )
     # Verify the template was processed with correct parameters
     mock_process_template.assert_called_once()
     call_args = mock_process_template.call_args
@@ -1356,7 +1356,7 @@ def test_process_reservation_without_team(mocker):
                 },
             }
         ]
-    } 
+    }
     # Mock file operations
     mock_path = mocker.patch("bonfire.processor.Path")
     mock_path.return_value.exists.return_value = True
@@ -1364,15 +1364,15 @@ def test_process_reservation_without_team(mocker):
         "mock template"
     )
     # Mock yaml.safe_load
-    mocker.patch("bonfire.processor.yaml.safe_load", return_value={"mock": "template"}) 
+    mocker.patch("bonfire.processor.yaml.safe_load", return_value={"mock": "template"})
     # Test without team parameter (should default to None)
     result = process_reservation(
         name="test-reservation", requester="test-user", duration="1h", pool="default"
-    ) 
+    )
     # Verify the template was processed with correct parameters
     mock_process_template.assert_called_once()
     call_args = mock_process_template.call_args
-    params = call_args[1]["params"] 
+    params = call_args[1]["params"]
     assert params["NAME"] == "test-reservation"
     assert params["REQUESTER"] == "test-user"
     assert params["DURATION"] == "1h"

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1285,8 +1285,7 @@ def test_process_reservation_with_team(mocker):
     Test that process_reservation correctly handles the team parameter
     """
     from bonfire.processor import process_reservation
-
-    
+ 
     # Mock the template processing
     mock_process_template = mocker.patch("bonfire.processor._process_template")
     mock_process_template.return_value = {
@@ -1304,18 +1303,17 @@ def test_process_reservation_with_team(mocker):
             }
         ]
     }
-    
+ 
     # Mock file operations
     mock_path = mocker.patch("bonfire.processor.Path")
     mock_path.return_value.exists.return_value = True
     mock_path.return_value.open.return_value.__enter__.return_value.read.return_value = (
         "mock template"
     )
-
-    
+ 
     # Mock yaml.safe_load
     mocker.patch("bonfire.processor.yaml.safe_load", return_value={"mock": "template"})
-    
+ 
     # Test with team parameter
     result = process_reservation(
         name="test-reservation",
@@ -1324,19 +1322,17 @@ def test_process_reservation_with_team(mocker):
         pool="default",
         team="test-team",
     )
-    
+ 
     # Verify the template was processed with correct parameters
     mock_process_template.assert_called_once()
     call_args = mock_process_template.call_args
     params = call_args[1]["params"]
-
-    
+ 
     assert params["NAME"] == "test-reservation"
     assert params["REQUESTER"] == "test-user"
     assert params["DURATION"] == "1h"
     assert params["POOL"] == "default"
-    assert params["TEAM"] == "test-team"
-    
+    assert params["TEAM"] == "test-team" 
 
     assert result == mock_process_template.return_value
 
@@ -1346,8 +1342,7 @@ def test_process_reservation_without_team(mocker):
     Test that process_reservation correctly handles None team parameter
     """
     from bonfire.processor import process_reservation
-    
-
+ 
     # Mock the template processing
     mock_process_template = mocker.patch("bonfire.processor._process_template")
     mock_process_template.return_value = {
@@ -1365,7 +1360,7 @@ def test_process_reservation_without_team(mocker):
             }
         ]
     }
-    
+ 
     # Mock file operations
     mock_path = mocker.patch("bonfire.processor.Path")
     mock_path.return_value.exists.return_value = True
@@ -1373,21 +1368,19 @@ def test_process_reservation_without_team(mocker):
         "mock template"
     )
 
-    
     # Mock yaml.safe_load
     mocker.patch("bonfire.processor.yaml.safe_load", return_value={"mock": "template"})
-    
+ 
     # Test without team parameter (should default to None)
     result = process_reservation(
         name="test-reservation", requester="test-user", duration="1h", pool="default"
     )
-    
+ 
     # Verify the template was processed with correct parameters
     mock_process_template.assert_called_once()
     call_args = mock_process_template.call_args
     params = call_args[1]["params"]
-    
-
+ 
     assert params["NAME"] == "test-reservation"
     assert params["REQUESTER"] == "test-user"
     assert params["DURATION"] == "1h"

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1298,7 +1298,7 @@ def test_process_reservation_with_team(mocker):
                     "duration": "1h",
                     "requester": "test-user",
                     "team": "test-team",
-                    "pool": "default"
+                    "pool": "default",
                 }
             }
         ]
@@ -1307,7 +1307,9 @@ def test_process_reservation_with_team(mocker):
     # Mock file operations
     mock_path = mocker.patch("bonfire.processor.Path")
     mock_path.return_value.exists.return_value = True
-    mock_path.return_value.open.return_value.__enter__.return_value.read.return_value = "mock template"
+    mock_path.return_value.open.return_value.__enter__.return_value.read.return_value = (
+        "mock template"
+    )
     
     # Mock yaml.safe_load
     mocker.patch("bonfire.processor.yaml.safe_load", return_value={"mock": "template"})
@@ -1318,7 +1320,7 @@ def test_process_reservation_with_team(mocker):
         requester="test-user", 
         duration="1h",
         pool="default",
-        team="test-team"
+        team="test-team",
     )
     
     # Verify the template was processed with correct parameters
@@ -1353,7 +1355,7 @@ def test_process_reservation_without_team(mocker):
                     "duration": "1h",
                     "requester": "test-user",
                     "team": None,
-                    "pool": "default"
+                    "pool": "default",
                 }
             }
         ]
@@ -1362,17 +1364,16 @@ def test_process_reservation_without_team(mocker):
     # Mock file operations
     mock_path = mocker.patch("bonfire.processor.Path")
     mock_path.return_value.exists.return_value = True
-    mock_path.return_value.open.return_value.__enter__.return_value.read.return_value = "mock template"
+    mock_path.return_value.open.return_value.__enter__.return_value.read.return_value = (
+        "mock template"
+    )
     
     # Mock yaml.safe_load
     mocker.patch("bonfire.processor.yaml.safe_load", return_value={"mock": "template"})
     
     # Test without team parameter (should default to None)
     result = process_reservation(
-        name="test-reservation",
-        requester="test-user", 
-        duration="1h",
-        pool="default"
+        name="test-reservation", requester="test-user", duration="1h", pool="default"
     )
     
     # Verify the template was processed with correct parameters

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1285,6 +1285,7 @@ def test_process_reservation_with_team(mocker):
     Test that process_reservation correctly handles the team parameter
     """
     from bonfire.processor import process_reservation
+
     
     # Mock the template processing
     mock_process_template = mocker.patch("bonfire.processor._process_template")
@@ -1299,7 +1300,7 @@ def test_process_reservation_with_team(mocker):
                     "requester": "test-user",
                     "team": "test-team",
                     "pool": "default",
-                }
+                },
             }
         ]
     }
@@ -1310,6 +1311,7 @@ def test_process_reservation_with_team(mocker):
     mock_path.return_value.open.return_value.__enter__.return_value.read.return_value = (
         "mock template"
     )
+
     
     # Mock yaml.safe_load
     mocker.patch("bonfire.processor.yaml.safe_load", return_value={"mock": "template"})
@@ -1317,7 +1319,7 @@ def test_process_reservation_with_team(mocker):
     # Test with team parameter
     result = process_reservation(
         name="test-reservation",
-        requester="test-user", 
+        requester="test-user",
         duration="1h",
         pool="default",
         team="test-team",
@@ -1327,6 +1329,7 @@ def test_process_reservation_with_team(mocker):
     mock_process_template.assert_called_once()
     call_args = mock_process_template.call_args
     params = call_args[1]["params"]
+
     
     assert params["NAME"] == "test-reservation"
     assert params["REQUESTER"] == "test-user"
@@ -1334,6 +1337,7 @@ def test_process_reservation_with_team(mocker):
     assert params["POOL"] == "default"
     assert params["TEAM"] == "test-team"
     
+
     assert result == mock_process_template.return_value
 
 
@@ -1343,6 +1347,7 @@ def test_process_reservation_without_team(mocker):
     """
     from bonfire.processor import process_reservation
     
+
     # Mock the template processing
     mock_process_template = mocker.patch("bonfire.processor._process_template")
     mock_process_template.return_value = {
@@ -1356,7 +1361,7 @@ def test_process_reservation_without_team(mocker):
                     "requester": "test-user",
                     "team": None,
                     "pool": "default",
-                }
+                },
             }
         ]
     }
@@ -1367,6 +1372,7 @@ def test_process_reservation_without_team(mocker):
     mock_path.return_value.open.return_value.__enter__.return_value.read.return_value = (
         "mock template"
     )
+
     
     # Mock yaml.safe_load
     mocker.patch("bonfire.processor.yaml.safe_load", return_value={"mock": "template"})
@@ -1381,10 +1387,12 @@ def test_process_reservation_without_team(mocker):
     call_args = mock_process_template.call_args
     params = call_args[1]["params"]
     
+
     assert params["NAME"] == "test-reservation"
     assert params["REQUESTER"] == "test-user"
     assert params["DURATION"] == "1h"
     assert params["POOL"] == "default"
     assert params["TEAM"] is None
     
+
     assert result == mock_process_template.return_value


### PR DESCRIPTION
# Purpose

The purpose of this change is to prompt the user for their team name which will get added on to the reserved ephemeral namespace. The new field will be added to `spec.team` on the `NamespaceReservation` resource. 

This change is intended to go along with [Ephemeral Namespace Operator MR #387](https://github.com/RedHatInsights/ephemeral-namespace-operator/pull/387)


Assisted-By: Cursor v1.2.4 / claude-4-sonnet