### PR TITLE
GraphQL Client: fetch_schema_from_transport set to false

### DIFF
--- a/bonfire/qontract.py
+++ b/bonfire/qontract.py
@@ -85,7 +85,7 @@ class Client:
         check_url_connection(transport_kwargs["url"])
 
         transport = RequestsHTTPTransport(**transport_kwargs)
-        self.client = GQLClient(transport=transport, fetch_schema_from_transport=True)
+        self.client = GQLClient(transport=transport, fetch_schema_from_transport=False)
 
         # info level is way too noisy for the gql client
         logging.getLogger("gql").setLevel(logging.ERROR)


### PR DESCRIPTION
We are getting deploy failures due to GraphQL errors:

```
06:26:55     raise TransportQueryError(
06:26:55 gql.transport.exceptions.TransportQueryError: Error while fetching schema: {'message': 'Unknown argument "includeDeprecated" on field "args" of type "__Directive".', 'locations': [{'line': 19, 'column': 12}], 'extensions': {'code': 'GRAPHQL_VALIDATION_FAILED'}}
06:26:55 If you don't need the schema, you can try with: "fetch_schema_from_transport=False"
```

This PR incorporates the feedback from the error message to set `fetch_schema_from_transport=False` for the client. This will disable schema introspection. 