### PR TITLE
Revert "Don't skip dependencies when using --component"

### DIFF
--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -824,7 +824,7 @@ class TemplateProcessor:
             processed_component.optional_deps_handled = True
 
         for component_name in all_dependencies:
-            self._process_component(component_name, app_name, in_recursion=True, is_dependency=True)
+            self._process_component(component_name, app_name, in_recursion=True)
 
     def _handle_dependencies(self, app_name, processed_component, in_recursion):
         items = processed_component.items
@@ -832,10 +832,10 @@ class TemplateProcessor:
             for name in conf.AUTO_ADDED_FRONTEND_DEPENDENCIES:
                 if name not in self.processed_components:
                     log.info("auto-adding %s as dependency for frontend resource", name)
-                    self._process_component(name, app_name, in_recursion, is_dependency=True)
+                    self._process_component(name, app_name, in_recursion)
         self._add_dependencies_to_config(app_name, processed_component, in_recursion)
 
-    def _process_component(self, component_name, app_name, in_recursion, is_dependency=False):
+    def _process_component(self, component_name, app_name, in_recursion):
         if component_name in self.processed_components:
             log.debug("template already processed for component '%s'", component_name)
             processed_component = self.processed_components[component_name]
@@ -853,7 +853,7 @@ class TemplateProcessor:
 
             processed_component = ProcessedComponent(component_name, items)
             self.processed_components[component_name] = processed_component
-            reason = self._component_skip_check(component_name, is_dependency)
+            reason = self._component_skip_check(component_name)
             if reason:
                 log.info("skipping component '%s', %s", component_name, reason)
             else:
@@ -869,16 +869,12 @@ class TemplateProcessor:
         for component in app_cfg["components"]:
             component_name = component["name"]
             log.debug("app '%s' has component '%s'", app_name, component_name)
-            self._process_component(
-                component_name, app_name, in_recursion=False, is_dependency=False
-            )
+            self._process_component(component_name, app_name, in_recursion=False)
 
-    def _component_skip_check(self, component_name, is_dependency) -> Optional[str]:
+    def _component_skip_check(self, component_name) -> Optional[str]:
         skip_reasons = [
             (
-                not is_dependency
-                and self.component_filter
-                and component_name not in self.component_filter,
+                self.component_filter and component_name not in self.component_filter,
                 "not found in --component filter",
             ),
             (


### PR DESCRIPTION
Reverts RedHatInsights/bonfire#490 ... this should cause bonfire to behave the same way it did in v6.3.0 with respect to `--component`: When `--component` is used, a component will only get deployed if it is explicitly listed in the `--component` filter. If it is not in this list, it will be skipped.