### PR TITLE
Track component apply

### DIFF
--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -773,12 +773,6 @@ class TemplateProcessor:
             fetch_optional_deps = True
             log.debug("parsing optionalDependencies for component '%s'", component_name)
 
-        log.debug(
-            "{} {} {}".format(
-                self.optional_deps_method, in_recursion, app_name in self.requested_app_names
-            )
-        )
-
         if (
             self.optional_deps_method == "hybrid"
             and not in_recursion  # in hyrbid mode, process optional deps only for top-level components

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -488,6 +488,7 @@ def test_mixed_deps(mock_repo_file, optional_deps_method, expected):
             [
                 "app5-component3",
                 "app5-component2",
+                "app1-component1"
             ],
         ),
         (
@@ -505,6 +506,8 @@ def test_mixed_deps_with_component_filter(mock_repo_file, optional_deps_method, 
     app5-component1 has 'app5-component2' listed under 'dependencies'
     app5-component1 has 'app5-component3' listed under 'optionalDependencies'
 
+    app5-component2 has 'app1-component1' listed under 'optionalDependencies'
+
     app5-component3 has 'app5-component2' listed under 'optionalDependencies'
 
     bonfire is run with '--component app5-component3'
@@ -514,15 +517,18 @@ def test_mixed_deps_with_component_filter(mock_repo_file, optional_deps_method, 
     """
     add_template(
         mock_repo_file,
+        "app1-component1",
+    )
+    add_template(
+        mock_repo_file,
         "app5-component1",
         deps=["app5-component2"],
         optional_deps=["app5-component3"],
     )
-    add_template(mock_repo_file, "app5-component2")
+    add_template(mock_repo_file, "app5-component2", optional_deps=["app1-component1"])
     add_template(
         mock_repo_file,
         "app5-component3",
-        deps=[],
         optional_deps=["app5-component2"],
     )
 

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -485,11 +485,7 @@ def test_mixed_deps(mock_repo_file, optional_deps_method, expected):
     [
         (
             "all",
-            [
-                "app5-component3",
-                "app5-component2",
-                "app1-component1"
-            ],
+            ["app5-component3", "app5-component2", "app1-component1"],
         ),
         (
             "hybrid",

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -286,6 +286,29 @@ def get_apps_config():
                 },
             ],
         },
+        "app5": {
+            "name": "app5",
+            "components": [
+                {
+                    "name": "app5-component1",
+                    "host": "local",
+                    "repo": "test",
+                    "path": "test",
+                },
+                {
+                    "name": "app5-component2",
+                    "host": "local",
+                    "repo": "test",
+                    "path": "test",
+                },
+                {
+                    "name": "app5-component3",
+                    "host": "local",
+                    "repo": "test",
+                    "path": "test",
+                },
+            ],
+        },
     }
 
 
@@ -453,6 +476,60 @@ def test_mixed_deps(mock_repo_file, optional_deps_method, expected):
     processor = get_processor(get_apps_config())
     processor.optional_deps_method = optional_deps_method
     processor.requested_app_names = ["app1"]
+    processed = processor.process()
+    assert_clowdapps(processed["items"], expected)
+
+
+@pytest.mark.parametrize(
+    "optional_deps_method,expected",
+    [
+        (
+            "all",
+            [
+                "app5-component3",
+                "app5-component2",
+            ],
+        ),
+        (
+            "hybrid",
+            [
+                "app5-component3",
+                "app5-component2",
+            ],
+        ),
+        ("none", ["app5-component3"]),
+    ],
+)
+def test_mixed_deps_with_component_filter(mock_repo_file, optional_deps_method, expected):
+    """
+    app5-component1 has 'app5-component2' listed under 'dependencies'
+    app5-component1 has 'app5-component3' listed under 'optionalDependencies'
+
+    app5-component3 has 'app5-component2' listed under 'optionalDependencies'
+
+    bonfire is run with '--component app5-component3'
+
+    test that processing app1 results in expected ClowdApp dependencies being pulled in depending
+    on what 'optional dependencies mode' is selected
+    """
+    add_template(
+        mock_repo_file,
+        "app5-component1",
+        deps=["app5-component2"],
+        optional_deps=["app5-component3"],
+    )
+    add_template(mock_repo_file, "app5-component2")
+    add_template(
+        mock_repo_file,
+        "app5-component3",
+        deps=[],
+        optional_deps=["app5-component2"],
+    )
+
+    processor = get_processor(get_apps_config())
+    processor.optional_deps_method = optional_deps_method
+    processor.requested_app_names = ["app5"]
+    processor.component_filter = ("app5-component3",)
     processed = processor.process()
     assert_clowdapps(processed["items"], expected)
 


### PR DESCRIPTION
The following scenario was not working:

* app 'myapp' has components: 1, 2, 3
* component 1 depends on component 2.
* component 3 also depends on component 2.
* bonfire is run with `bonfire process myapp --component 3`

Component 2 does not initially get applied because the 'component_skip_check' removes it (as it should)

When it comes time for component 2 to get pulled by component 3, bonfire thinks it has already processed component 2 and skips it.