### PR TITLE
Fix dependency processing in components with multiple ClowdApps

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,20 @@ When bonfire processes templates, if it finds a ClowdApp, it will do the followi
     * You will end up with all components of `app-a`, `app-b-clowdapp`, AND `app-c-clowdapp` deployed into the namespace.
   * `none`: `bonfire` will ignore the `optionalDependencies` on all ClowdApps that it encounters
 
+Dependency deployment can be fine-tuned with the `--remove-dependency` and `--no-remove-dependency` options.  If a component name is given, all dependencies for that component will be removed or preserved, respectively.  Individual dependencies can be targeted by joining the component name and dependency name together with a `/` character.  For example:
+
+```shell
+$ bonfire deploy myApp --remove-dependency component1/unwanted-component
+```
+
+A more specific designation will always take precedence over a general one.  Consider
+
+```shell
+$ bonfire deploy myApp --remove-dependency component1 --no-remove-dependency component1/retained-dependency
+```
+
+In this case, all of `component1`'s dependencies **except** `retained-dependency` will be removed.
+
 # Configuration Details
 
 > NOTE: for information related to app-interface configurations, see the internal [ConsoleDot Docs](https://consoledot.pages.redhat.com/)

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -218,33 +218,31 @@ def _alter_dependency_config(items, component_name, keep, remove):
         if i["kind"] != "ClowdApp":
             continue
         name = i["metadata"]["name"]
-        if name == component_name:
-            deps = set(i["spec"].get("dependencies", []))
-            optional_deps = set(i["spec"].get("optionalDependencies", []))
+        deps = set(i["spec"].get("dependencies", []))
+        optional_deps = set(i["spec"].get("optionalDependencies", []))
 
-            all_deps = deps.union(optional_deps)
-            for modification_set in [keep, remove]:
-                if modification_set not in special_designations and not modification_set.issubset(
-                    all_deps
-                ):
-                    raise click.ClickException(
-                        f"Elements listed in {modification_set} not present in "
-                        f"dependencies {all_deps}"
-                    )
+        all_deps = deps.union(optional_deps)
+        for modification_set in [keep, remove]:
+            if modification_set not in special_designations and not modification_set.issubset(
+                all_deps
+            ):
+                raise click.ClickException(
+                    f"Elements listed in {modification_set} not present in dependencies {all_deps}"
+                )
 
-            modified_dependencies = _resolve_dependency_overrides(
-                set(i["spec"].get("dependencies", [])), keep, remove
-            )
-            i["spec"]["dependencies"] = list(modified_dependencies)
-            log.debug(f"set dependencies for ClowdApp {name} to {modified_dependencies}")
+        modified_dependencies = _resolve_dependency_overrides(
+            set(i["spec"].get("dependencies", [])), keep, remove
+        )
+        i["spec"]["dependencies"] = list(modified_dependencies)
+        log.debug(f"set dependencies for ClowdApp {name} to {modified_dependencies}")
 
-            modified_optional_dependencies = _resolve_dependency_overrides(
-                set(i["spec"].get("optionalDependencies", [])), keep, remove
-            )
-            i["spec"]["optionalDependencies"] = list(modified_optional_dependencies)
-            log.debug(
-                f"set optionalDependencies for ClowdApp {name} to {modified_optional_dependencies}"
-            )
+        modified_optional_dependencies = _resolve_dependency_overrides(
+            set(i["spec"].get("optionalDependencies", [])), keep, remove
+        )
+        i["spec"]["optionalDependencies"] = list(modified_optional_dependencies)
+        log.debug(
+            f"set optionalDependencies for ClowdApp {name} to {modified_optional_dependencies}"
+        )
 
 
 def _set_replicas(items):


### PR DESCRIPTION
The code was erroneously limiting dependency processing to ClowdApps that match the component name exactly.  While this is often the case, it is possible for a component to contain multiple ClowdApps.