### PR TITLE
Log namespace events on deployment fail

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -38,7 +38,7 @@ from bonfire.openshift import (
     get_console_url,
     get_pool_size_limit,
     get_reserved_namespace_quantity,
-    _log_namespace_events,
+    log_namespace_events,
 )
 from bonfire.processor import TemplateProcessor, process_clowd_env, process_iqe_cji
 from bonfire.qontract import get_apps_for_env, sub_refs
@@ -1295,7 +1295,7 @@ def _deploy_err_handler(err, no_release_on_fail, reserved_new_ns, reserve, ns):
         log.exception("hit unexpected error!")
 
     if ns:
-        _log_namespace_events(ns, only_show_errors=True)
+        log_namespace_events(ns, only_show_errors=True)
 
     try:
         if not no_release_on_fail and reserved_new_ns and not reserve:

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -38,6 +38,7 @@ from bonfire.openshift import (
     get_console_url,
     get_pool_size_limit,
     get_reserved_namespace_quantity,
+    _log_namespace_events,
 )
 from bonfire.processor import TemplateProcessor, process_clowd_env, process_iqe_cji
 from bonfire.qontract import get_apps_for_env, sub_refs
@@ -1292,6 +1293,9 @@ def _deploy_err_handler(err, no_release_on_fail, reserved_new_ns, reserve, ns):
         log.error(msg)
     else:
         log.exception("hit unexpected error!")
+
+    if ns:
+        _log_namespace_events(ns, only_show_errors=True)
 
     try:
         if not no_release_on_fail and reserved_new_ns and not reserve:

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -393,7 +393,7 @@ def _log_namespace_events(namespace, only_show_errors=False):
     log.info("Retrieving events from namespace '%s'...\n", namespace)
 
     def retrieve_namespace_events():
-        events_output = oc("get", "events", "-n", namespace, "--no-headers", _ok_code=[0, 1], _silent=True)
+        events_output = oc("get", "events", "-n", namespace, "--no-headers", _ok_code=[0, 1], _silent=False)
         event_lines = events_output.strip().split('\n') if events_output.strip() else []
 
         events = []
@@ -417,21 +417,21 @@ def _log_namespace_events(namespace, only_show_errors=False):
         return events
 
     events = retrieve_namespace_events()
-    if only_show_errors and not events:
-        log.info("No errors or warnings found in namespace '%s'", namespace)
-        return
-    
-    # Log the most relevant events (limit to first 20)
-    for i, event in enumerate(events[:20]):
-        event_type = event["type"]
-        reason = event["reason"]
-        obj_name = event["obj_name"]
-        message = event["message"]
-        timestamp = event["timestamp"]
-        
-        # Format the event with better structure
-        log.error("  [%d] %s | %s | %s | %s | %s", i + 1, timestamp, event_type, reason, obj_name, message)
-    
-    if len(events) > 20:
-        log.error("  ... and %d more events (showing first 20)", len(events) - 20)
+    # if only_show_errors and not events:
+    #     log.info("No errors or warnings found in namespace '%s'", namespace)
+    #     return
+    #
+    # # Log the most relevant events (limit to first 20)
+    # for i, event in enumerate(events[:20]):
+    #     event_type = event["type"]
+    #     reason = event["reason"]
+    #     obj_name = event["obj_name"]
+    #     message = event["message"]
+    #     timestamp = event["timestamp"]
+    #
+    #     # Format the event with better structure
+    #     log.error("  [%d] %s | %s | %s | %s | %s", i + 1, timestamp, event_type, reason, obj_name, message)
+    #
+    # if len(events) > 20:
+    #     log.error("  ... and %d more events (showing first 20)", len(events) - 20)
     log.info("="*100)

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -383,3 +383,55 @@ def get_reserved_namespace_quantity(pool):
     ]
 
     return len(reserved_namespaces)
+
+
+def _log_namespace_events(namespace, only_show_errors=False):
+    """
+    Retrieve and log namespace events.
+    """
+    log.info("="*100)
+    log.info("Retrieving events from namespace '%s'...\n", namespace)
+
+    def retrieve_namespace_events():
+        events_output = oc("get", "events", "-n", namespace, "--no-headers", _ok_code=[0, 1], _silent=True)
+        event_lines = events_output.strip().split('\n') if events_output.strip() else []
+
+        events = []
+        for line in event_lines:
+            event_data = line.split(None, 4)
+
+            timestamp = event_data[0]
+            event_type = event_data[1]
+            reason = event_data[2]
+            obj_name = event_data[3]
+            message = event_data[4]
+
+            if not only_show_errors or event_type in ["Warning", "Error"]:
+                events.append({
+                    "timestamp": timestamp,
+                    "type": event_type,
+                    "reason": reason,
+                    "obj_name": obj_name,
+                    "message": message
+                })
+        return events
+
+    events = retrieve_namespace_events()
+    if only_show_errors and not events:
+        log.info("No errors or warnings found in namespace '%s'", namespace)
+        return
+    
+    # Log the most relevant events (limit to first 20)
+    for i, event in enumerate(events[:20]):
+        event_type = event["type"]
+        reason = event["reason"]
+        obj_name = event["obj_name"]
+        message = event["message"]
+        timestamp = event["timestamp"]
+        
+        # Format the event with better structure
+        log.error("  [%d] %s | %s | %s | %s | %s", i + 1, timestamp, event_type, reason, obj_name, message)
+    
+    if len(events) > 20:
+        log.error("  ... and %d more events (showing first 20)", len(events) - 20)
+    log.info("="*100)

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -385,7 +385,7 @@ def get_reserved_namespace_quantity(pool):
     return len(reserved_namespaces)
 
 
-def _log_namespace_events(namespace, only_show_errors=False):
+def log_namespace_events(namespace, only_show_errors=False):
     """
     Retrieve and log namespace events.
     """
@@ -393,45 +393,7 @@ def _log_namespace_events(namespace, only_show_errors=False):
     log.info("Retrieving events from namespace '%s'...\n", namespace)
 
     def retrieve_namespace_events():
-        events_output = oc("get", "events", "-n", namespace, "--no-headers", _ok_code=[0, 1], _silent=False)
-        event_lines = events_output.strip().split('\n') if events_output.strip() else []
-
-        events = []
-        for line in event_lines:
-            event_data = line.split(None, 4)
-
-            timestamp = event_data[0]
-            event_type = event_data[1]
-            reason = event_data[2]
-            obj_name = event_data[3]
-            message = event_data[4]
-
-            if not only_show_errors or event_type in ["Warning", "Error"]:
-                events.append({
-                    "timestamp": timestamp,
-                    "type": event_type,
-                    "reason": reason,
-                    "obj_name": obj_name,
-                    "message": message
-                })
-        return events
+        events_output = oc("get", "events", "-n", namespace, "--no-headers", "--field-selector", f"type={'Warning' if only_show_errors else 'Normal'}", _ok_code=[0, 1], _silent=False)
 
     events = retrieve_namespace_events()
-    # if only_show_errors and not events:
-    #     log.info("No errors or warnings found in namespace '%s'", namespace)
-    #     return
-    #
-    # # Log the most relevant events (limit to first 20)
-    # for i, event in enumerate(events[:20]):
-    #     event_type = event["type"]
-    #     reason = event["reason"]
-    #     obj_name = event["obj_name"]
-    #     message = event["message"]
-    #     timestamp = event["timestamp"]
-    #
-    #     # Format the event with better structure
-    #     log.error("  [%d] %s | %s | %s | %s | %s", i + 1, timestamp, event_type, reason, obj_name, message)
-    #
-    # if len(events) > 20:
-    #     log.error("  ... and %d more events (showing first 20)", len(events) - 20)
     log.info("="*100)

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -392,8 +392,6 @@ def log_namespace_events(namespace, only_show_errors=False):
     log.info("="*100)
     log.info("Retrieving events from namespace '%s'...\n", namespace)
 
-    def retrieve_namespace_events():
-        events_output = oc("get", "events", "-n", namespace, "--no-headers", "--field-selector", f"type={'Warning' if only_show_errors else 'Normal'}", _ok_code=[0, 1], _silent=False)
+    oc("get", "events", "-n", namespace, "--no-headers", "--field-selector", f"type={'Warning' if only_show_errors else 'Normal'}", _ok_code=[0, 1], _silent=False)
 
-    events = retrieve_namespace_events()
     log.info("="*100)

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -389,9 +389,19 @@ def log_namespace_events(namespace, only_show_errors=False):
     """
     Retrieve and log namespace events.
     """
-    log.info("="*100)
+    log.info("=" * 100)
     log.info("Retrieving events from namespace '%s'...\n", namespace)
 
-    oc("get", "events", "-n", namespace, "--no-headers", "--field-selector", f"type={'Warning' if only_show_errors else 'Normal'}", _ok_code=[0, 1], _silent=False)
+    oc(
+        "get",
+        "events",
+        "-n",
+        namespace,
+        "--no-headers",
+        "--field-selector",
+        f"type={'Warning' if only_show_errors else 'Normal'}",
+        _ok_code=[0, 1],
+        _silent=False
+    )
 
-    log.info("="*100)
+    log.info("=" * 100)

--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -401,7 +401,7 @@ def log_namespace_events(namespace, only_show_errors=False):
         "--field-selector",
         f"type={'Warning' if only_show_errors else 'Normal'}",
         _ok_code=[0, 1],
-        _silent=False
+        _silent=False,
     )
 
     log.info("=" * 100)


### PR DESCRIPTION
Closes [RHCLOUD-29114](https://issues.redhat.com/browse/RHCLOUD-29114)

### Change Details
* Added `log_namespace_events` method in `openshift.py` - this invokes `oc get events` for the target namespace, and allows the user to specify a flag for filtering errors
* Added event logging in the `deploy_error_handler` in `bonfire.py`