### PR TITLE
fix(processor): validate dependencies only for matching ClowdApp in "--remove-dependencies component/dependency" syntax

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -588,10 +588,10 @@ _process_options = _app_source_options + [
         "--remove-dependencies",
         help=(
             "Remove dependencies/optionalDependencies on ClowdApp configs "
-            "for specific components or apps. Prefix the app name with "
-            "'app:', otherwise specify the component name. (default: none). "
+            "for specific ClowdApps or app groups. For an app group, prefix name with "
+            "'app:', otherwise specify the ClowdApp name. (default: none). "
             "Specific dependencies can be specified with a slash delimiter. "
-            "E.g. mycomponent/rbac"
+            "E.g. myclowdapp/rbac"
         ),
         type=str,
         multiple=True,
@@ -601,10 +601,10 @@ _process_options = _app_source_options + [
         "--no-remove-dependencies",
         help=(
             "Don't remove dependencies/optionalDependencies on ClowdApp configs "
-            "for specific components or apps. Prefix the app name with "
-            "'app:', otherwise specify the component name. (default: all). "
+            "for specific ClowdApps or app groups. For an app group, prefix name with "
+            "'app:', otherwise specify the ClowdApp name. (default: all). "
             "Specific dependencies can be specified with a slash delimiter. "
-            "E.g. mycomponent/rbac"
+            "E.g. myclowdapp/rbac"
         ),
         type=str,
         multiple=True,


### PR DESCRIPTION
## Problem

When using the `--remove-dependencies component/dependency` syntax, bonfire would validate the specified dependencies against **all** ClowdApps in the template, not just the one matching the component name. This caused failures when:

- A template contains multiple ClowdApps
- Only one ClowdApp has the dependency you want to remove
- Other ClowdApps in the template don't have that dependency

### Example of the failing scenario:

```bash
bonfire --remove-dependencies swatch-contracts/rbac 
```

Would fail with:
```
Elements listed in {'rbac'} not present in dependencies {'swatch-database'}
```

Even though `rbac` exists in the `swatch-contracts` ClowdApp, because `swatch-contracts-db-cleanup` (another ClowdApp in the same template) doesn't have `rbac` as a dependency.

## Solution

Modified the `_alter_dependency_config` function to:

1. **Detect specific dependency syntax**: When `remove` or `keep` sets contain specific dependencies (not wildcards or `None`), it indicates the `component/dependency` syntax was used
2. **Selective validation and modification**: Only validate and modify the ClowdApp whose name matches the `component_name` parameter
3. **Preserve existing behavior**: When using wildcards (`*`) or default values (`None`), continue to apply changes to all ClowdApps

### Behavior Changes

| Command | Before | After |
|---------|--------|-------|
| `--remove-dependencies swatch-contracts/rbac` | ❌ Validates `rbac` against ALL ClowdApps | ✅ Validates `rbac` only against `swatch-contracts` ClowdApp |
| `--remove-dependencies swatch-contracts` | ✅ Removes all deps from ALL ClowdApps | ✅ Same behavior (unchanged) |

## Testing

Added comprehensive tests covering:

- ✅ `test_alter_dependency_config_specific_clowdapp_only`: Verifies only matching ClowdApp is modified with specific syntax
- ✅ `test_alter_dependency_config_wildcard_affects_all`: Verifies wildcards still affect all ClowdApps  
- ✅ `test_alter_dependency_config_validates_only_matching_clowdapp`: Verifies validation occurs only on matching ClowdApp

## Backward Compatibility

This change is **fully backward compatible**:
- Existing commands using wildcards or no specific dependencies work exactly as before
- Only the buggy behavior with `component/dependency` syntax is fixed
- No breaking changes to the API or command-line interface