### PR TITLE
fix: handle missing keycloak secret in namespace describe

### DIFF
--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -427,8 +427,13 @@ def parse_fe_env(project_name):
 def get_keycloak_creds(project_name):
     secret = get_json("secret", name=f"env-{project_name}-keycloak", namespace=project_name)
     kc_creds = {}
-    for key in ("username", "password", "defaultUsername", "defaultPassword"):
-        kc_creds[key] = decode_b64(secret["data"][key])
+    if secret and "data" in secret:
+        for key in ("username", "password", "defaultUsername", "defaultPassword"):
+            kc_creds[key] = decode_b64(secret["data"].get(key, ""))
+    else:
+        # Namespace might be terminating or secret doesn't exist
+        for key in ("username", "password", "defaultUsername", "defaultPassword"):
+            kc_creds[key] = "N/A"
     return kc_creds
 
 


### PR DESCRIPTION
## Summary

Fixes #281

When running the reproducer from the issue:
```
bonfire namespace reserve
bonfire namespace release
bonfire namespace describe
```

A KeyError occurs because the keycloak secret is removed during namespace cleanup, but the describe command tries to access it without checking if it exists first.

## Changes

- Added check for secret existence and 'data' field before accessing
- Return 'N/A' for credentials when secret is missing
- Prevents crashes when describing a namespace during termination

## Test plan

- Run the reproducer steps - describe should now work even during release
- Existing tests should continue to pass
- Manual testing with namespace in various states (active, terminating)