### PR TITLE
fix: validate GITHUB_TOKEN before making API requests

### DIFF
--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -252,7 +252,7 @@ def validate_github_token():
             log.warning(
                 "GITHUB_TOKEN validation returned status %s. "
                 "Token may be invalid or have insufficient permissions.",
-                response.status_code
+                response.status_code,
             )
     except requests.exceptions.RequestException as e:
         log.warning("Could not validate GITHUB_TOKEN: %s", str(e))


### PR DESCRIPTION
## Summary
- Adds validation for GITHUB_TOKEN before making GitHub API requests
- Provides clear error message when token is invalid or expired

## Details
When a user's GITHUB_TOKEN expires, bonfire would attempt to fetch files from GitHub and receive 404 errors. This made it difficult to diagnose that the actual problem was an expired token rather than missing files.

The error looked like:
```
http response 404 for url https://raw.githubusercontent.com/..., checking for template in current working dir...
failed to fetch template file for curiosity-frontend
hit fatal error: [Errno 2] No such file or directory: '/home/user/deploy/frontend.yaml'
```

## Changes
- Added `validate_github_token()` function that tests the token with a simple API call to `/user` endpoint
- Integrated validation into `_gh_auth_headers` cached property (runs only once on first use)
- If token returns 401 (Unauthorized), raises a FatalError with a helpful message directing users to check `.config/bonfire/env` or environment variables
- For other error statuses, logs a warning but continues (to handle network issues gracefully)
- Validation only runs if GITHUB_TOKEN is set

## Testing
- Verified function only validates when GITHUB_TOKEN is present
- Clear error message helps users quickly identify token expiration issues
- Uses cached_property so validation only happens once per session

Fixes #362