### PR TITLE
fix: truncate requester label to 63 chars

### DIFF
--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -416,6 +416,8 @@ def process_reservation(
             requester = "bonfire"
 
     params["REQUESTER"] = requester
+    # Truncate requester to 63 chars for label (k8s label value limit)
+    params["REQUESTER_LABEL"] = requester[:63]
     params["TEAM"] = team or ""
     params["POOL"] = pool if pool else "default"
 

--- a/bonfire/resources/reservation-template.yaml
+++ b/bonfire/resources/reservation-template.yaml
@@ -9,7 +9,7 @@ objects:
   metadata:
     name: ${NAME}
     labels:
-      requester: ${REQUESTER}
+      requester: ${REQUESTER_LABEL}
   spec:
     duration: ${DURATION}
     requester: ${REQUESTER}
@@ -21,8 +21,10 @@ parameters:
   required: true
 - name: REQUESTER
   required: true
+- name: REQUESTER_LABEL
+  required: true
 - name: TEAM
-  required: false 
+  required: false
 - name: NAME
   required: true
 - name: POOL


### PR DESCRIPTION
fixes #288

the namespace reservation was failing when the requester value exceeded 63 characters (kubernetes label value limit). this happened with long jenkins job names like `automation-analytics-automation-analytics-backend-cypress-pr-check-2` (69 chars).

## changes

- added `REQUESTER_LABEL` parameter in processor.py that truncates the requester to 63 chars
- updated reservation template to use `REQUESTER_LABEL` for the metadata label
- kept full `REQUESTER` value in spec.requester (no length restriction there)

now reservations work with any requester value length.