### PR TITLE
fix: add secrets_src_namespace to _cmd_deploy_iqe_cji

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -1775,6 +1775,7 @@ def _cmd_deploy_iqe_cji(
     custom_env_vars,
     pool,
     force,
+    secrets_src_namespace,
     defer_status_errors,
 ):
     """Process IQE CJI template, apply it, and wait for it to start running."""
@@ -1784,7 +1785,8 @@ def _cmd_deploy_iqe_cji(
     _namespace = get_namespace_from_context(ctx, namespace, required=True)
 
     namespace, _ = _get_namespace(
-        _namespace, name, requester, team, duration, pool, timeout, local, force
+        _namespace, name, requester, team, duration, pool, timeout, local, force,
+        secrets_src_namespace=secrets_src_namespace,
     )
 
     cji_config = process_iqe_cji(

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -1785,7 +1785,15 @@ def _cmd_deploy_iqe_cji(
     _namespace = get_namespace_from_context(ctx, namespace, required=True)
 
     namespace, _ = _get_namespace(
-        _namespace, name, requester, team, duration, pool, timeout, local, force,
+        _namespace,
+        name,
+        requester,
+        team,
+        duration,
+        pool,
+        timeout,
+        local,
+        force,
         secrets_src_namespace=secrets_src_namespace,
     )
 


### PR DESCRIPTION
## Summary

- `_cmd_deploy_iqe_cji` was missing `secrets_src_namespace` in its function signature after #540 added the `--secrets-src-namespace` option to the shared `_namespace_reserve_options` decorator list
- Added `secrets_src_namespace` to the function signature and passed it through to `_get_namespace`

Fixes #542

## Test plan

- [ ] Run `bonfire deploy-iqe-cji` — confirm no `TypeError: _cmd_deploy_iqe_cji() got an unexpected keyword argument 'secrets_src_namespace'`
- [ ] Run with `--secrets-src-namespace <ns>` to verify the parameter is correctly forwarded to namespace reservation

🤖 Generated with [Claude Code](https://claude.com/claude-code)