### PR TITLE
fix: rosa alias component filter and namespace mismatch in config deploy

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -1621,7 +1621,7 @@ def _cmd_config_deploy(
             local,
             frontends,
             preferred_params,
-            _namespace,
+            ns,
             exclude_components,
         )
         log.debug("app configs:\n%s", json.dumps(apps_config, indent=2))

--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -162,7 +162,7 @@ DEFAULT_ALIASES = {
         "app_names": ["ephemeral"],
         "args": {
             "target_env": "rosa-ephemeral",
-            "component_filter": ["rosa-cluster"],
+            "component_filter": ["rosa-ephemeral-cluster"],
             "pool": "rosa",
         },
     },

--- a/tests/test_bonfire.py
+++ b/tests/test_bonfire.py
@@ -500,7 +500,7 @@ class TestCLIAliases:
                     "app_names": ["ephemeral"],
                     "args": {
                         "target_env": "rosa-ephemeral",
-                        "component_filter": ["rosa-cluster"],
+                        "component_filter": ["rosa-ephemeral-cluster"],
                     },
                 }
             },
@@ -510,7 +510,7 @@ class TestCLIAliases:
         app_names, overrides = bonfire._resolve_alias(ctx, ("rosa",), None)
         assert app_names == ("ephemeral",)
         assert overrides["target_env"] == "rosa-ephemeral"
-        assert overrides["component_filter"] == ["rosa-cluster"]
+        assert overrides["component_filter"] == ["rosa-ephemeral-cluster"]
 
     def test_alias_user_override_takes_precedence(self, mocker):
         mocker.patch(
@@ -520,7 +520,7 @@ class TestCLIAliases:
                     "app_names": ["ephemeral"],
                     "args": {
                         "target_env": "rosa-ephemeral",
-                        "component_filter": ["rosa-cluster"],
+                        "component_filter": ["rosa-ephemeral-cluster"],
                     },
                 }
             },
@@ -530,7 +530,7 @@ class TestCLIAliases:
         app_names, overrides = bonfire._resolve_alias(ctx, ("rosa",), None)
         assert app_names == ("ephemeral",)
         assert "target_env" not in overrides
-        assert overrides["component_filter"] == ["rosa-cluster"]
+        assert overrides["component_filter"] == ["rosa-ephemeral-cluster"]
 
     def test_no_alias_match_passes_through(self, mocker):
         mocker.patch("bonfire.config.load_aliases", return_value={})
@@ -579,7 +579,7 @@ class TestCLIAliases:
                     "app_names": ["ephemeral"],
                     "args": {
                         "target_env": "rosa-ephemeral",
-                        "component_filter": ["rosa-cluster"],
+                        "component_filter": ["rosa-ephemeral-cluster"],
                     },
                 }
             },


### PR DESCRIPTION
## Summary
- Updates the `component_filter` in `DEFAULT_ALIASES` for the `rosa` alias from `rosa-cluster` to `rosa-ephemeral-cluster`
- Fixes a bug in `_cmd_config_deploy` where templates were processed with a stale namespace when the current namespace was expired/unowned; now passes the resolved (post-reservation) namespace to `_process`

## Test plan
- [ ] Existing alias tests pass with the updated component filter value
- [ ] `bonfire config deploy` correctly applies templates to the reserved namespace when the current namespace is expired or unowned

🤖 Generated with [Claude Code](https://claude.com/claude-code)