### PR TITLE
Update IQE CJI spec, include ibutsu refs

### DIFF
--- a/bonfire/resources/default-iqe-cji.yaml
+++ b/bonfire/resources/default-iqe-cji.yaml
@@ -42,6 +42,24 @@ objects:
             value: ${IBUTSU_SOURCE}
           - name: IQE_ENABLE_MINIO
             value: "true"
+          - name: IBUTSU_MODE
+            valueFrom:
+              configMapKeyRef:
+                name: ibutsu-config
+                key: IBUTSU_MODE
+                optional: true
+          - name: IBUTSU_PROJECT
+            valueFrom:
+              configMapKeyRef:
+                name: ibutsu-config
+                key: IBUTSU_PROJECT
+                optional: true
+          - name: IBUTSU_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: iqe-ibutsu-token
+                key: IBUTSU_TOKEN
+                optional: true
 
 parameters:
 - name: NAME

--- a/bonfire/resources/default-iqe-cji.yaml
+++ b/bonfire/resources/default-iqe-cji.yaml
@@ -45,19 +45,19 @@ objects:
           - name: IBUTSU_MODE
             valueFrom:
               configMapKeyRef:
-                name: ibutsu-config
+                name: ${IBUTSU_CONFIGMAP}
                 key: IBUTSU_MODE
                 optional: true
           - name: IBUTSU_PROJECT
             valueFrom:
               configMapKeyRef:
-                name: ibutsu-config
+                name: ${IBUTSU_CONFIGMAP}
                 key: IBUTSU_PROJECT
                 optional: true
           - name: IBUTSU_TOKEN
             valueFrom:
               secretKeyRef:
-                name: iqe-ibutsu-token
+                name: ${IBUTSU_SECRET}
                 key: IBUTSU_TOKEN
                 optional: true
 
@@ -95,4 +95,8 @@ parameters:
   value: ""
 - name: IBUTSU_SOURCE
   value: ""
+- name: IBUTSU_CONFIGMAP
+  value: "ibutsu-config"
+- name: IBUTSU_SECRET
+  value: "iqe-ibutsu-token"
 

--- a/bonfire_lib/core_resources.py
+++ b/bonfire_lib/core_resources.py
@@ -67,6 +67,8 @@ def render_cji(
     parallel_worker_count: str = "2",
     rp_args: str = "",
     ibutsu_source: str = "",
+    ibutsu_configmap: str = "ibutsu-config",
+    ibutsu_secret: str = "iqe-ibutsu-token",
 ) -> dict:
     """Render a ClowdJobInvocation CR as a Python dict."""
     template = _env.get_template("clowdjobinvocation.yaml.j2")
@@ -87,6 +89,8 @@ def render_cji(
         parallel_worker_count=parallel_worker_count,
         rp_args=rp_args,
         ibutsu_source=ibutsu_source,
+        ibutsu_configmap=ibutsu_configmap,
+        ibutsu_secret=ibutsu_secret,
     )
     return yaml.safe_load(rendered)
 

--- a/bonfire_lib/templates/clowdjobinvocation.yaml.j2
+++ b/bonfire_lib/templates/clowdjobinvocation.yaml.j2
@@ -36,3 +36,21 @@ spec:
           value: "{{ ibutsu_source | default('') }}"
         - name: IQE_ENABLE_MINIO
           value: "true"
+        - name: IBUTSU_MODE
+          valueFrom:
+            configMapKeyRef:
+              name: ibutsu-config
+              key: IBUTSU_MODE
+              optional: true
+        - name: IBUTSU_PROJECT
+          valueFrom:
+            configMapKeyRef:
+              name: ibutsu-config
+              key: IBUTSU_PROJECT
+              optional: true
+        - name: IBUTSU_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: iqe-ibutsu-token
+              key: IBUTSU_TOKEN
+              optional: true

--- a/bonfire_lib/templates/clowdjobinvocation.yaml.j2
+++ b/bonfire_lib/templates/clowdjobinvocation.yaml.j2
@@ -39,18 +39,18 @@ spec:
         - name: IBUTSU_MODE
           valueFrom:
             configMapKeyRef:
-              name: ibutsu-config
+              name: {{ ibutsu_configmap | default('ibutsu-config') }}
               key: IBUTSU_MODE
               optional: true
         - name: IBUTSU_PROJECT
           valueFrom:
             configMapKeyRef:
-              name: ibutsu-config
+              name: {{ ibutsu_configmap | default('ibutsu-config') }}
               key: IBUTSU_PROJECT
               optional: true
         - name: IBUTSU_TOKEN
           valueFrom:
             secretKeyRef:
-              name: iqe-ibutsu-token
+              name: {{ ibutsu_secret | default('iqe-ibutsu-token') }}
               key: IBUTSU_TOKEN
               optional: true

--- a/tests/test_bonfire_lib/test_core_resources.py
+++ b/tests/test_bonfire_lib/test_core_resources.py
@@ -95,7 +95,8 @@ class TestRenderCji:
     def test_env_vars_present(self):
         result = render_cji("test-cji", "my-app")
         env_list = result["spec"]["testing"]["iqe"]["env"]
-        env_dict = {e["name"]: e["value"] for e in env_list}
+        env_dict = {e["name"]: e["value"] for e in env_list if "value" in e}
+        value_from_dict = {e["name"]: e["valueFrom"] for e in env_list if "valueFrom" in e}
         assert "IQE_MARKER_EXPRESSION" in env_dict
         assert "IQE_FILTER_EXPRESSION" in env_dict
         assert "IQE_PLUGINS" in env_dict
@@ -104,6 +105,12 @@ class TestRenderCji:
         assert env_dict["IQE_PARALLEL_ENABLED"] == "true"
         assert env_dict["IQE_PARALLEL_WORKER_COUNT"] == "2"
         assert env_dict["IQE_ENABLE_MINIO"] == "true"
+        assert "IBUTSU_MODE" in value_from_dict
+        assert value_from_dict["IBUTSU_MODE"]["configMapKeyRef"]["name"] == "ibutsu-config"
+        assert "IBUTSU_PROJECT" in value_from_dict
+        assert value_from_dict["IBUTSU_PROJECT"]["configMapKeyRef"]["name"] == "ibutsu-config"
+        assert "IBUTSU_TOKEN" in value_from_dict
+        assert value_from_dict["IBUTSU_TOKEN"]["secretKeyRef"]["name"] == "iqe-ibutsu-token"
 
     def test_custom_values(self):
         result = render_cji(
@@ -123,7 +130,7 @@ class TestRenderCji:
         assert iqe["debug"] is True
         assert iqe["ui"]["selenium"]["deploy"] is True
 
-        env_dict = {e["name"]: e["value"] for e in iqe["env"]}
+        env_dict = {e["name"]: e["value"] for e in iqe["env"] if "value" in e}
         assert env_dict["ENV_FOR_DYNACONF"] == "custom_env"
         assert env_dict["IQE_MARKER_EXPRESSION"] == "smoke"
         assert env_dict["IQE_FILTER_EXPRESSION"] == "test_login"

--- a/tests/test_bonfire_lib/test_core_resources.py
+++ b/tests/test_bonfire_lib/test_core_resources.py
@@ -124,6 +124,8 @@ class TestRenderCji:
             deploy_selenium=True,
             parallel_enabled="false",
             parallel_worker_count="4",
+            ibutsu_configmap="my-ibutsu-cm",
+            ibutsu_secret="my-ibutsu-secret",
         )
         spec = result["spec"]
         iqe = spec["testing"]["iqe"]
@@ -137,3 +139,8 @@ class TestRenderCji:
         assert env_dict["IQE_PLUGINS"] == "my_plugin"
         assert env_dict["IQE_PARALLEL_ENABLED"] == "false"
         assert env_dict["IQE_PARALLEL_WORKER_COUNT"] == "4"
+
+        value_from_dict = {e["name"]: e["valueFrom"] for e in iqe["env"] if "valueFrom" in e}
+        assert value_from_dict["IBUTSU_MODE"]["configMapKeyRef"]["name"] == "my-ibutsu-cm"
+        assert value_from_dict["IBUTSU_PROJECT"]["configMapKeyRef"]["name"] == "my-ibutsu-cm"
+        assert value_from_dict["IBUTSU_TOKEN"]["secretKeyRef"]["name"] == "my-ibutsu-secret"


### PR DESCRIPTION
### What
* use valueFrom refs for ephemeral-base resources
* This used to be baked into the iqe-tests image, terrible idea. Now it's included in resources for the namespace operator

### Related

This clowder update will make the references actually work - but it doesn't block this PR since the fields are all optional.

- [x] https://github.com/RedHatInsights/clowder/pull/1766