### PR TITLE
Update ocviapy to v1.6.1 and fix deploy/alias bugs

### DIFF
--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -164,6 +164,7 @@ DEFAULT_ALIASES = {
             "target_env": "rosa-ephemeral",
             "component_filter": ["rosa-ephemeral-cluster"],
             "pool": "rosa",
+            "timeout": 1800,
         },
     },
 }

--- a/bonfire/config.py
+++ b/bonfire/config.py
@@ -165,6 +165,7 @@ DEFAULT_ALIASES = {
             "component_filter": ["rosa-ephemeral-cluster"],
             "pool": "rosa",
             "timeout": 1800,
+            "duration": "2h",
         },
     },
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ cli = [
     "importlib-resources; python_version<'3.9'",
     "junitparser",
     "multidict",
-    "ocviapy>=1.6.0",
+    "ocviapy>=1.6.1",
     "python-dotenv",
     "requests>=2.33.0",
     "sh",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ cli = [
     "importlib-resources; python_version<'3.9'",
     "junitparser",
     "multidict",
-    "ocviapy>=1.6.1",
+    "ocviapy>=1.6.2",
     "python-dotenv",
     "requests>=2.33.0",
     "sh",

--- a/tests/test_bonfire.py
+++ b/tests/test_bonfire.py
@@ -559,6 +559,8 @@ class TestCLIAliases:
                     "args": {
                         "target_env": "rosa-ephemeral",
                         "component_filter": ["rosa-ephemeral-cluster"],
+                        "timeout": 1800,
+                        "duration": "2h",
                     },
                 }
             },
@@ -569,6 +571,8 @@ class TestCLIAliases:
         assert app_names == ("ephemeral",)
         assert overrides["target_env"] == "rosa-ephemeral"
         assert overrides["component_filter"] == ["rosa-ephemeral-cluster"]
+        assert overrides["timeout"] == 1800
+        assert overrides["duration"] == "2h"
 
     def test_alias_user_override_takes_precedence(self, mocker):
         mocker.patch(


### PR DESCRIPTION
## Summary
- Update `ocviapy` dependency from `>=1.6.0` to `>=1.6.1`
- Fix namespace mismatch in `_cmd_config_deploy`: when the current namespace is expired/unowned and a new one is reserved, pass the resolved namespace (`ns`) to `_process` instead of the stale pre-reservation value (`_namespace`)
- Fix the `rosa` default alias component filter from `rosa-cluster` to `rosa-ephemeral-cluster`, and add a default `timeout: 1800`

## Test plan
- [x] Tests updated to reflect the new `rosa-ephemeral-cluster` component filter
- [ ] Verify `bonfire config deploy` works correctly when namespace reservation occurs
- [ ] Verify `bonfire deploy --alias rosa` picks up the updated component filter and timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)