### PR TITLE
fix: accept 'Available' condition for CAPI cluster readiness check

### DIFF
--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -247,7 +247,7 @@ class Namespace:
         for cluster in items:
             conditions = cluster.get("status", {}).get("conditions", [])
             for cond in conditions:
-                if cond.get("type") == "Ready" and cond.get("status") == "True":
+                if cond.get("type") in ("Ready", "Available") and cond.get("status") == "True":
                     ready += 1
                     break
 


### PR DESCRIPTION
## Summary
- `bonfire namespace list` was showing clusters as not ready (`0/1`) even when fully operational
- Newer Cluster API versions (v1beta2+) use an `Available` condition instead of `Ready`
- Updated the condition check in `Namespace.clusters` to accept either `Ready` or `Available`

## Test plan
- [ ] Run `bonfire namespace list` against a namespace with a CAPI v1beta2+ cluster and verify it shows `1/1` instead of `0/1`
- [ ] Verify older clusters using the `Ready` condition still report correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)