### PR TITLE
feat: improve 'namespace describe' CLI output

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -36,7 +36,6 @@ from bonfire.openshift import (
     wait_for_db_resources,
     wait_on_cji,
     whoami,
-    get_console_url,
     get_pool_size_limit,
     get_reserved_namespace_quantity,
     log_namespace_events,
@@ -1637,16 +1636,13 @@ def _cmd_config_deploy(
     else:
         log.info("successfully deployed to namespace %s", ns)
         es_telemetry.send_telemetry("successful deployment")
-        url = get_console_url()
-        if url:
-            ns_url = f"{url}/k8s/cluster/projects/{ns}"
-            log.info("namespace url: %s", ns_url)
-            log.info(
-                "resource usage dashboard for namespace '%s': %s",
-                ns,
-                conf.RESOURCE_DASHBOARD_URL.format(namespace=ns),
-            )
+        log.info(
+            "resource usage dashboard for namespace '%s': %s",
+            ns,
+            conf.RESOURCE_DASHBOARD_URL.format(namespace=ns),
+        )
         click.echo(ns)
+        log.info("for namespace access information, run 'bonfire namespace describe %s'", ns)
 
 
 def _process_clowdenv(namespace, quay_user, clowd_env, template_file, local):

--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -4,6 +4,8 @@ import datetime
 import json
 import logging
 
+from tabulate import tabulate
+
 from ocviapy import get_all_namespaces, get_json, on_k8s, set_current_namespace
 from wait_for import TimedOutError
 
@@ -380,15 +382,51 @@ def describe_namespace(project_name: str, output: str):
     if output == "json":
         return json.dumps(info, indent=2)
 
-    data = f"\nCurrent project: {project_name}\n"
+    rows = [("Namespace", project_name)]
     if info.get("console_namespace_route"):
-        data += f"Project URL: {info['console_namespace_route']}\n"
-    data += f"Keycloak admin route: {info['keycloak_admin_route']}\n"
-    data += f"Keycloak admin login: {info['keycloak_admin_username']} | {info['keycloak_admin_password']}\n"
-    data += f"{info['clowdapps_deployed']} ClowdApp(s), {info['frontends_deployed']} Frontend(s) deployed\n"
-    data += f"Gateway route: {info['gateway_route']}\n"
-    data += f"Default user login: {info['default_username']} | {info['default_password']}\n"
-    return data
+        rows.append(("Project URL", info["console_namespace_route"]))
+    if info.get("gateway_route"):
+        rows.append(("Gateway route", info["gateway_route"]))
+    if info.get("clowdapps_deployed"):
+        rows.append(("ClowdApps deployed", info["clowdapps_deployed"]))
+    if info.get("frontends_deployed"):
+        rows.append(("Frontends deployed", info["frontends_deployed"]))
+
+    def _has_cred(user, pw):
+        return user not in ("", "N/A") or pw not in ("", "N/A")
+
+    cred_rows = []
+    if _has_cred(info["keycloak_admin_username"], info["keycloak_admin_password"]):
+        cred_rows.append(("Keycloak admin", info["keycloak_admin_route"], info["keycloak_admin_username"], info["keycloak_admin_password"]))
+    if _has_cred(info["default_username"], info["default_password"]):
+        cred_rows.append(("Default user", "", info["default_username"], info["default_password"]))
+
+    lines = [tabulate(rows, tablefmt="simple")]
+
+    if cred_rows:
+        lines.append("\nCredentials:")
+        for name, route, user, pw in cred_rows:
+            cred_info = [
+                (f"{name} username", user),
+                (f"{name} password", pw),
+            ]
+            if route:
+                cred_info.append((f"{name} route", route))
+            lines.append(tabulate(cred_info, tablefmt="simple"))
+            lines.append("")
+
+    if info.get("has_cluster"):
+        ns = project_name
+        lines.append(
+            "ROSA Cluster configuration detected! To access it, run:\n"
+            "\n"
+            f"  oc get secret {ns}-cluster-kubeconfig \\\n"
+            f"    -n {ns} \\\n"
+            f"    -o jsonpath='{{.data.value}}' | base64 -d > /tmp/{ns}-kubeconfig\n"
+            f"  KUBECONFIG=/tmp/{ns}-kubeconfig oc whoami"
+        )
+
+    return "\n" + "\n".join(lines) + "\n"
 
 
 def parse_fe_env(project_name):

--- a/bonfire/namespaces.py
+++ b/bonfire/namespaces.py
@@ -397,7 +397,14 @@ def describe_namespace(project_name: str, output: str):
 
     cred_rows = []
     if _has_cred(info["keycloak_admin_username"], info["keycloak_admin_password"]):
-        cred_rows.append(("Keycloak admin", info["keycloak_admin_route"], info["keycloak_admin_username"], info["keycloak_admin_password"]))
+        cred_rows.append(
+            (
+                "Keycloak admin",
+                info["keycloak_admin_route"],
+                info["keycloak_admin_username"],
+                info["keycloak_admin_password"],
+            )
+        )
     if _has_cred(info["default_username"], info["default_password"]):
         cred_rows.append(("Default user", "", info["default_username"], info["default_password"]))
 

--- a/bonfire_lib/status.py
+++ b/bonfire_lib/status.py
@@ -190,6 +190,8 @@ def describe_namespace(client: EphemeralK8sClient, namespace: str) -> dict:
     console_url = get_console_url(client)
     ns_url = f"{console_url}/k8s/cluster/projects/{namespace}" if console_url else ""
 
+    has_cluster = _has_cluster_kubeconfig(client, namespace)
+
     return {
         "namespace": namespace,
         "console_namespace_route": ns_url,
@@ -201,7 +203,17 @@ def describe_namespace(client: EphemeralK8sClient, namespace: str) -> dict:
         "default_username": kc_creds.get("defaultUsername", "N/A"),
         "default_password": kc_creds.get("defaultPassword", "N/A"),
         "gateway_route": f"https://{fe_host}" if fe_host else "",
+        "has_cluster": has_cluster,
     }
+
+
+def _has_cluster_kubeconfig(client: EphemeralK8sClient, namespace: str) -> bool:
+    """Check if a cluster kubeconfig secret exists in the namespace."""
+    try:
+        secret = client.get_secret(f"{namespace}-cluster-kubeconfig", namespace)
+        return secret is not None
+    except Exception:
+        return False
 
 
 def _get_keycloak_creds(client: EphemeralK8sClient, namespace: str) -> dict:


### PR DESCRIPTION
## Summary
- Use `tabulate` to format `bonfire namespace describe` output into clean, aligned tables
- Hide empty/zero fields: gateway route, deploy counts, and credentials are omitted when not available
- Display "ROSA Cluster configuration detected!" with kubeconfig instructions when a cluster is present

## Test plan
- [ ] Run `bonfire namespace describe` on a namespace with all fields populated — verify aligned table output
- [ ] Run on a namespace with no gateway route, 0 deploys, and no credentials — verify those sections are omitted
- [ ] Run on a namespace with a ROSA cluster — verify cluster instructions appear
- [ ] Run with `-o json` — verify JSON output is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)