### PR TITLE
feat: Add DEPLOY_PLAYWRIGHT parameter to default IQE CJI template

### DIFF
--- a/bonfire/resources/default-iqe-cji.yaml
+++ b/bonfire/resources/default-iqe-cji.yaml
@@ -17,6 +17,8 @@ objects:
         ui:
           selenium:
             deploy: ${{DEPLOY_SELENIUM}}
+          playwright:
+            deploy: ${{DEPLOY_PLAYWRIGHT}}
         env:
           - name: IQE_MARKER_EXPRESSION
             value: ${MARKER}
@@ -68,6 +70,8 @@ parameters:
 - name: PLUGINS
   value: ""
 - name: DEPLOY_SELENIUM
+  value: "false"
+- name: DEPLOY_PLAYWRIGHT
   value: "false"
 - name: PARALLEL_ENABLED
   value: "true"


### PR DESCRIPTION
Add support for deploying Playwright container alongside or instead of Selenium for UI testing in IQE jobs.

Users can now deploy Playwright with:
  bonfire deploy-iqe-cji --param DEPLOY_PLAYWRIGHT=true

This aligns with the new Playwright container support added to Clowder's ClowdJobInvocation CRD in https://github.com/RedHatInsights/clowder/pull/1772.