### PR TITLE
fix: falling back to in-cluster when kubeconfig contain invalid

### DIFF
--- a/bonfire_lib/k8s_client.py
+++ b/bonfire_lib/k8s_client.py
@@ -11,7 +11,8 @@ import os
 import tempfile
 
 from kubernetes import client, config
-from kubernetes.client import ApiException
+from kubernetes.client import ApisApi, ApiException
+from kubernetes.config import ConfigException
 from kubernetes.dynamic import DynamicClient
 
 log = logging.getLogger(__name__)
@@ -79,28 +80,33 @@ class EphemeralK8sClient:
             # Try kubeconfig first, then fall back to in-cluster auth.
             # This ensures that explicit `oc login` credentials are used even when
             # running inside a pod (e.g., GitLab CI runners).
-            kubeconfig_loaded = False
             try:
                 config.load_kube_config(
                     config_file=kubeconfig_path,
                     context=context,
                 )
-                kubeconfig_loaded = True
+                # Verify that the kubeconfig actually works by probing /apis
+                test_client = client.ApiClient()
+                ApisApi(test_client).get_api_versions()
+                # If we get here, kubeconfig is valid and works
                 self._auth_mode = "kubeconfig"
-                self._api_client = client.ApiClient()
-            except config.ConfigException:
-                # No valid kubeconfig found
-                pass
+                self._api_client = test_client
+            except (ConfigException, ApiException) as e:
+                # Kubeconfig doesn't exist, is invalid, or doesn't have working credentials
+                log.error(
+                    "Kubeconfig auth failed (%s: %s), attempting in-cluster fallback",
+                    e.__class__.__name__,
+                    str(e)[:100],
+                )
 
-            if not kubeconfig_loaded:
                 if self._is_in_cluster():
                     self._auth_mode = "in-cluster"
                     config.load_incluster_config()
                     self._api_client = client.ApiClient()
                 else:
-                    raise config.ConfigException(
+                    raise ConfigException(
                         "Unable to load kubeconfig and not running in-cluster"
-                    )
+                    ) from e
 
         self._dynamic = DynamicClient(self._api_client)
         self._core_v1 = client.CoreV1Api(self._api_client)

--- a/tests/test_bonfire_lib/test_k8s_client.py
+++ b/tests/test_bonfire_lib/test_k8s_client.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch, MagicMock
 
 from kubernetes.config import ConfigException
+from kubernetes.client import ApiException
 from bonfire_lib.k8s_client import EphemeralK8sClient, _sanitize_username, _extract_username
 
 
@@ -60,7 +61,6 @@ class TestAuthModeSelection:
 
         # Mock kubeconfig load to fail, so it falls back to in-cluster
         mock_config.load_kube_config.side_effect = ConfigException("No kubeconfig")
-        mock_config.ConfigException = ConfigException
 
         EphemeralK8sClient()
         mock_config.load_incluster_config.assert_called_once()
@@ -79,6 +79,33 @@ class TestAuthModeSelection:
             config_file="/tmp/kubeconfig",
             context="mycontext",
         )
+
+    @patch("bonfire_lib.k8s_client.DynamicClient")
+    @patch("bonfire_lib.k8s_client.ApisApi")
+    @patch("bonfire_lib.k8s_client.client")
+    @patch("bonfire_lib.k8s_client.config")
+    @patch.object(EphemeralK8sClient, "_is_in_cluster", return_value=True)
+    def test_kubeconfig_invalid_fallback_to_incluster(
+        self, mock_in_cluster, mock_config, mock_client_module, mock_apis_api, mock_dynamic
+    ):
+        """Test that when kubeconfig loads but /apis call fails, it falls back to in-cluster"""
+        mock_api_client = MagicMock()
+        mock_client_module.ApiClient.return_value = mock_api_client
+        mock_client_module.CoreV1Api.return_value = MagicMock()
+
+        # Mock kubeconfig load succeeds
+        mock_config.load_kube_config.return_value = None
+        # But ApisApi call fails with 403 Forbidden (invalid credentials on /apis)
+        mock_apis_instance = MagicMock()
+        mock_apis_instance.get_api_versions.side_effect = ApiException(
+            status=403, reason="Forbidden"
+        )
+        mock_apis_api.return_value = mock_apis_instance
+
+        EphemeralK8sClient()
+
+        # Should have fallen back to in-cluster
+        mock_config.load_incluster_config.assert_called_once()
 
     @patch("bonfire_lib.k8s_client.DynamicClient")
     @patch("bonfire_lib.k8s_client.client")


### PR DESCRIPTION
bonfire 6.13 regression: fails when kubeconfig exists but contains invalid credentials.

**Timeline:**
- **6.12.0:** Prioritized in-cluster over kubeconfig → broke GitLab CI (pods without permissions)
- **6.13.0:** Fixed GitLab CI by prioritizing kubeconfig → broke other pods where kubeconfig loads but has invalid credentials (`system:anonymous`)

**Current failure in 6.13:**
```
forbidden: User "system:anonymous" cannot get path "/apis"
```

Root cause: `load_kube_config()` succeeds even with broken credentials. Code assumes "loaded = working", which is wrong.