### PR TITLE
feat: automatically pass _KUBE_API_SERVER param to templates

### DIFF
--- a/bonfire/openshift.py
+++ b/bonfire/openshift.py
@@ -61,6 +61,14 @@ def has_clowder():
 
 # we will assume that 'oc whoami' will not change during execution
 @functools.lru_cache(maxsize=None, typed=False)
+def get_kube_api_server():
+    try:
+        return oc("whoami", "--show-server", _silent=True).strip()
+    except Exception:
+        return "unknown"
+
+
+@functools.lru_cache(maxsize=None, typed=False)
 def whoami():
     name = oc("whoami", _silent=True).strip()
     # a valid label must be an empty string or consist of alphanumeric characters,

--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -14,7 +14,7 @@ from ocviapy import process_template
 from sh import ErrorReturnCode
 
 import bonfire.config as conf
-from bonfire.openshift import whoami
+from bonfire.openshift import get_kube_api_server, whoami
 from bonfire.utils import AppOrComponentSelector, FatalError, RepoFile
 from bonfire.utils import get_clowdapp_dependencies
 from bonfire.utils import get_dependencies as utils_get_dependencies
@@ -316,6 +316,7 @@ def process_clowd_env(target_ns, quay_user, env_name, template_path, local=True)
         params["PULL_SECRET_NAME"] = f"{quay_user}-pull-secret"
     if target_ns:
         params["NAMESPACE"] = target_ns
+    params["_KUBE_API_SERVER"] = get_kube_api_server()
 
     processed_template = _process_template(template_data, params=params, local=local)
 
@@ -849,6 +850,7 @@ class TemplateProcessor:
         # set NAMESPACE on this component only if it is current unset
         if "NAMESPACE" not in params:
             params["NAMESPACE"] = self.namespace
+        params["_KUBE_API_SERVER"] = get_kube_api_server()
 
         # always override ENV_NAME
         params["ENV_NAME"] = self.clowd_env


### PR DESCRIPTION
## Summary

- Adds `get_kube_api_server()` to `openshift.py`, which runs `oc whoami --show-server` and returns `"unknown"` on any exception. The result is cached via `lru_cache` to avoid repeated subprocess calls.
- Sets `params["_KUBE_API_SERVER"]` alongside `params["NAMESPACE"]` in both template-processing paths in `processor.py`: the ClowdEnvironment path and the per-component path in `TemplateProcessor`.

## Test plan

- [ ] Deploy a ClowdEnvironment and confirm `_KUBE_API_SERVER` is passed with the correct server URL
- [ ] Deploy an app component and confirm `_KUBE_API_SERVER` is present in processed template params
- [ ] Verify fallback: simulate `oc whoami --show-server` failure and confirm `_KUBE_API_SERVER` is set to `"unknown"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)