### PR TITLE
feat: sync CJI expected-image-tag annotation after image tag overrides

### DIFF
--- a/bonfire/processor.py
+++ b/bonfire/processor.py
@@ -776,7 +776,7 @@ class TemplateProcessor:
         else:
             raise FatalError(f"component with name '{component_name}' not found")
 
-    def _sub_image_tags(self, items):
+    def _sub_image_tags(self, items, original_image_tag=None):
         content = json.dumps(items)
         for image, image_tag in self.image_tag_overrides.items():
             # easier to just re.sub on a whole string
@@ -784,7 +784,73 @@ class TemplateProcessor:
             if subs:
                 self.counter["image_tag_overrides"][image] += subs
                 log.info("replaced %d occurence(s) of image tag for image '%s'", subs, image)
-        return json.loads(content)
+        items = json.loads(content)
+
+        if self.image_tag_overrides:
+            self._sync_cji_expected_image_tag(items, original_image_tag)
+
+        return items
+
+    def _sync_cji_expected_image_tag(self, items, original_image_tag=None):
+        """Update expected-image-tag annotations on ClowdJobInvocations to match
+        the actual image tag present in the associated ClowdApp job specs.
+
+        When --set-image-tag overrides images (e.g. to a digest), the CJI annotation
+        must reflect the new tag so Clowder's image-gate check passes.
+
+        Only updates annotations whose value matches the original IMAGE_TAG parameter,
+        indicating they were set via ${IMAGE_TAG} in the template. Custom annotation
+        values are left untouched.
+        """
+        ANNOTATION_KEY = "clowder.redhat.com/expected-image-tag"
+
+        # collect actual image tags from ClowdApp job specs, keyed by (app_name, job_name)
+        # to avoid cross-app collisions when multiple ClowdApps define jobs with the same name
+        job_image_tags = {}
+        for item in items:
+            if item.get("kind") == "ClowdApp":
+                app_name = item.get("metadata", {}).get("name", "")
+                for job in item.get("spec", {}).get("jobs", []):
+                    image = job.get("podSpec", {}).get("image", "")
+                    if ":" in image:
+                        tag = image.rsplit(":", 1)[1]
+                        job_image_tags[(app_name, job.get("name", ""))] = tag
+
+        # update CJI annotations to match the resolved image tag
+        for item in items:
+            if item.get("kind") != "ClowdJobInvocation":
+                continue
+            annotations = item.get("metadata", {}).get("annotations", {})
+            if ANNOTATION_KEY not in annotations:
+                continue
+
+            old_val = annotations[ANNOTATION_KEY]
+
+            # only update if the annotation was derived from IMAGE_TAG
+            if original_image_tag and old_val != original_image_tag:
+                log.debug(
+                    "skipping expected-image-tag on CJI '%s': value '%s' does not match IMAGE_TAG '%s'",
+                    item.get("metadata", {}).get("name", "unknown"),
+                    old_val,
+                    original_image_tag,
+                )
+                continue
+
+            cji_app_name = item.get("spec", {}).get("appName", "")
+            cji_jobs = item.get("spec", {}).get("jobs", [])
+            for job_name in cji_jobs:
+                key = (cji_app_name, job_name)
+                if key in job_image_tags:
+                    new_val = job_image_tags[key]
+                    if old_val != new_val:
+                        annotations[ANNOTATION_KEY] = new_val
+                        log.info(
+                            "updated expected-image-tag on CJI '%s': '%s' -> '%s'",
+                            item.get("metadata", {}).get("name", "unknown"),
+                            old_val,
+                            new_val,
+                        )
+                    break
 
     def _sub_ref(self, current_component_name, repo_file):
         for component_name, value in self.template_ref_overrides.items():
@@ -887,7 +953,7 @@ class TemplateProcessor:
         new_items = _process_template(template, params, self.local)["items"]
 
         # override the tags for all occurences of an image if requested
-        new_items = self._sub_image_tags(new_items)
+        new_items = self._sub_image_tags(new_items, params.get("IMAGE_TAG"))
 
         # evaluate --remove-dependencies/--no-remove-dependencies
         should_alter_deps = _should_alter(

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1648,3 +1648,186 @@ def test_alter_dependency_config_validates_only_matching_clowdapp():
 
     assert "not present in dependencies" in str(exc_info.value)
     assert "app1-component1" in str(exc_info.value)
+
+
+class TestSyncCjiExpectedImageTag:
+    """Tests for _sync_cji_expected_image_tag which updates the expected-image-tag
+    annotation on ClowdJobInvocations after image tag overrides."""
+
+    ANNOTATION_KEY = "clowder.redhat.com/expected-image-tag"
+
+    def _make_items(self, job_image, annotation_value):
+        """Helper to build a ClowdApp + CJI item list."""
+        items = [
+            {
+                "kind": "ClowdApp",
+                "metadata": {"name": "my-app"},
+                "spec": {"jobs": [{"name": "run-db-migrations", "podSpec": {"image": job_image}}]},
+            },
+            {
+                "kind": "ClowdJobInvocation",
+                "metadata": {
+                    "name": "run-db-migrations-abc1234",
+                    "annotations": {self.ANNOTATION_KEY: annotation_value},
+                },
+                "spec": {"appName": "my-app", "jobs": ["run-db-migrations"]},
+            },
+        ]
+        return items
+
+    def _get_processor_with_overrides(self, image_tag_overrides):
+        apps_config = get_apps_config()
+        return TemplateProcessor(
+            apps_config=apps_config,
+            app_names=[],
+            get_dependencies=True,
+            optional_deps_method="hybrid",
+            image_tag_overrides=image_tag_overrides,
+            template_ref_overrides={},
+            param_overrides={},
+            clowd_env="some_env",
+            remove_resources=AppOrComponentSelector(True, [], []),
+            no_remove_resources=AppOrComponentSelector(False, [], []),
+            remove_dependencies=AppOrComponentSelector(False, [], []),
+            no_remove_dependencies=AppOrComponentSelector(True, [], []),
+            single_replicas=True,
+            component_filter=[],
+            local=True,
+            frontends=False,
+        )
+
+    def test_updates_annotation_when_image_tag_matches(self):
+        """When the annotation matches IMAGE_TAG and the image was overridden,
+        the annotation should be updated to the new tag (after the last colon)."""
+        items = self._make_items(
+            job_image="quay.io/my-org/my-app:sha256:fa35bb2b938d",
+            annotation_value="abc1234",
+        )
+        processor = self._get_processor_with_overrides(
+            {"quay.io/my-org/my-app": "sha256:fa35bb2b938d"}
+        )
+        processor._sync_cji_expected_image_tag(items, original_image_tag="abc1234")
+
+        cji = items[1]
+        # rsplit(":", 1) extracts the part after the last colon
+        assert cji["metadata"]["annotations"][self.ANNOTATION_KEY] == "fa35bb2b938d"
+
+    def test_skips_when_annotation_does_not_match_image_tag(self):
+        """When the annotation has a custom value (not from IMAGE_TAG),
+        it should be left untouched."""
+        items = self._make_items(
+            job_image="quay.io/my-org/my-app:sha256:fa35bb2b938d",
+            annotation_value="my-custom-value",
+        )
+        processor = self._get_processor_with_overrides(
+            {"quay.io/my-org/my-app": "sha256:fa35bb2b938d"}
+        )
+        processor._sync_cji_expected_image_tag(items, original_image_tag="abc1234")
+
+        cji = items[1]
+        assert cji["metadata"]["annotations"][self.ANNOTATION_KEY] == "my-custom-value"
+
+    def test_skips_cji_without_annotation(self):
+        """CJIs without the expected-image-tag annotation should be ignored."""
+        items = [
+            {
+                "kind": "ClowdApp",
+                "metadata": {"name": "my-app"},
+                "spec": {
+                    "jobs": [
+                        {
+                            "name": "run-db-migrations",
+                            "podSpec": {"image": "quay.io/my-org/my-app:newdigest"},
+                        }
+                    ]
+                },
+            },
+            {
+                "kind": "ClowdJobInvocation",
+                "metadata": {"name": "run-db-migrations-abc1234", "annotations": {}},
+                "spec": {"appName": "my-app", "jobs": ["run-db-migrations"]},
+            },
+        ]
+        processor = self._get_processor_with_overrides({"quay.io/my-org/my-app": "newdigest"})
+        processor._sync_cji_expected_image_tag(items, original_image_tag="abc1234")
+
+        cji = items[1]
+        assert self.ANNOTATION_KEY not in cji["metadata"]["annotations"]
+
+    def test_no_update_when_tags_already_match(self):
+        """If the annotation already matches the job image tag, no update needed."""
+        items = self._make_items(
+            job_image="quay.io/my-org/my-app:abc1234",
+            annotation_value="abc1234",
+        )
+        processor = self._get_processor_with_overrides({"quay.io/my-org/my-app": "abc1234"})
+        processor._sync_cji_expected_image_tag(items, original_image_tag="abc1234")
+
+        cji = items[1]
+        assert cji["metadata"]["annotations"][self.ANNOTATION_KEY] == "abc1234"
+
+    def test_handles_no_clowdapp_jobs(self):
+        """If the ClowdApp has no jobs, CJI annotation is left untouched."""
+        items = [
+            {
+                "kind": "ClowdApp",
+                "metadata": {"name": "my-app"},
+                "spec": {"jobs": []},
+            },
+            {
+                "kind": "ClowdJobInvocation",
+                "metadata": {
+                    "name": "run-db-migrations-abc1234",
+                    "annotations": {self.ANNOTATION_KEY: "abc1234"},
+                },
+                "spec": {"appName": "my-app", "jobs": ["run-db-migrations"]},
+            },
+        ]
+        processor = self._get_processor_with_overrides({"quay.io/my-org/my-app": "newdigest"})
+        processor._sync_cji_expected_image_tag(items, original_image_tag="abc1234")
+
+        cji = items[1]
+        assert cji["metadata"]["annotations"][self.ANNOTATION_KEY] == "abc1234"
+
+    def test_disambiguates_by_app_name(self):
+        """When multiple ClowdApps have jobs with the same name, the CJI should
+        only pick the tag from the ClowdApp matching its spec.appName."""
+        items = [
+            {
+                "kind": "ClowdApp",
+                "metadata": {"name": "app-a"},
+                "spec": {
+                    "jobs": [
+                        {
+                            "name": "run-db-migrations",
+                            "podSpec": {"image": "quay.io/org/app-a:tag-a"},
+                        }
+                    ]
+                },
+            },
+            {
+                "kind": "ClowdApp",
+                "metadata": {"name": "app-b"},
+                "spec": {
+                    "jobs": [
+                        {
+                            "name": "run-db-migrations",
+                            "podSpec": {"image": "quay.io/org/app-b:tag-b"},
+                        }
+                    ]
+                },
+            },
+            {
+                "kind": "ClowdJobInvocation",
+                "metadata": {
+                    "name": "run-db-migrations-abc1234",
+                    "annotations": {self.ANNOTATION_KEY: "abc1234"},
+                },
+                "spec": {"appName": "app-b", "jobs": ["run-db-migrations"]},
+            },
+        ]
+        processor = self._get_processor_with_overrides({"quay.io/org/app-b": "tag-b"})
+        processor._sync_cji_expected_image_tag(items, original_image_tag="abc1234")
+
+        cji = items[2]
+        assert cji["metadata"]["annotations"][self.ANNOTATION_KEY] == "tag-b"


### PR DESCRIPTION
When --set-image-tag overrides images (e.g. to a digest from a Konflux SNAPSHOT), the ClowdJobInvocation expected-image-tag annotation still holds the original IMAGE_TAG value. Clowder then cannot match the annotation against the new image reference and the migration job never runs.

After image tag substitution, inspect ClowdApp job images and update the expected-image-tag annotation on CJIs to match the actual resolved tag. Only updates annotations whose value matches the original IMAGE_TAG parameter to avoid overwriting custom values.

This PR is a follow up on: https://github.com/RedHatInsights/clowder/pull/1779