### PR TITLE
feat: add install script and improve install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ As an example, typing `bonfire deploy host-inventory` leads to the host-inventor
 
 - [About](#about)
 - [Installation](#installation)
+  - [GitHub token configuration](#github-token-configuration)
 - [MCP Server (AI Agent Integration)](#mcp-server-ai-agent-integration)
   - [Installing the MCP Server](#installing-the-mcp-server)
   - [Authentication](#authentication)
@@ -83,28 +84,6 @@ python3 -m venv $VENV_DIR
 pip install crc-bonfire
 ```
 
-To prevent GitHub rate limiting issues when bonfire reaches out to GitHub APIs,
-[create a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
-on your GitHub account which grants bonfire read access to your repos.
-
-**Token Expiration**: The token must have an expiration length of less than 366 days to adhere to organizational policies. Longer periods will result in 403 responses.
-
-**Tokens (Classic)**: When using the GitHub token (classic), it **must have** the `read:project` scope.
-In addition, since some projects may be private, you will need to add the `repo` (full control of private repositories) scope too.
-for the template fetching to work!
-
-**Fine-grained tokens**: When using the newer fine grained tokens in GitHub, you must select the following permissions for `All Repositories` with read-only permission.
-* Contents (Read-only)
-* Metadata (required and included by default)
-
-![GitHub Token Example](github-fine-token.png)
-
-Configure bonfire to use the token with:
-```
-echo 'GITHUB_TOKEN=<your api token>' >> ~/.config/bonfire/env
-```
-
-
 ## Using UV
 
 If you have `uv` installed on your system, you can also quickly install the bonfire tool globally on your system with:
@@ -154,6 +133,29 @@ If you desire for the kubeconfig to live in a non-standard location in the conta
 podman run -it --rm --userns=keep-id:uid=1000,gid=1000 -v $HOME/.kube/config:/opt/kubeconfig:Z \
     -e KUBECONFIG=/opt/kubeconfig \
     quay.io/redhat-user-workloads/hcm-eng-prod-tenant/bonfire/bonfire namespace list
+```
+
+## GitHub token configuration
+
+To prevent GitHub rate limiting issues when bonfire reaches out to GitHub APIs,
+[create a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+on your GitHub account which grants bonfire read access to your repos.
+
+**Token Expiration**: The token must have an expiration length of less than 366 days to adhere to organizational policies. Longer periods will result in 403 responses.
+
+**Tokens (Classic)**: When using the GitHub token (classic), it **must have** the `read:project` scope.
+In addition, since some projects may be private, you will need to add the `repo` (full control of private repositories) scope too.
+for the template fetching to work!
+
+**Fine-grained tokens**: When using the newer fine grained tokens in GitHub, you must select the following permissions for `All Repositories` with read-only permission.
+* Contents (Read-only)
+* Metadata (required and included by default)
+
+![GitHub Token Example](github-fine-token.png)
+
+Configure bonfire to use the token with:
+```
+echo 'GITHUB_TOKEN=<your api token>' >> ~/.config/bonfire/env
 ```
 
 # MCP Server (AI Agent Integration)

--- a/README.md
+++ b/README.md
@@ -91,13 +91,6 @@ If you have `uv` installed on your system, you can also quickly install the bonf
 uv tool install crc-bonfire
 ```
 
-## Using homebrew
-
-```bash
-brew tap redhatinsights/bonfire
-brew install bonfire
-```
-
 ## Using a container image (podman/docker)
 
 We provide a container image at quay.io/redhat-user-workloads/hcm-eng-prod-tenant/bonfire/bonfire. The image wraps a Python virtual environment with **crc-bonfire** installed on it.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,29 @@ A wide range of CLI options allow you to customize exactly what combination of c
 
 # Installation
 
-## Installing locally
+## Quick install (recommended)
+
+Run the install script to automatically set up a virtualenv and install bonfire:
+
+```bash
+bash <(curl -sSL https://raw.githubusercontent.com/RedHatInsights/bonfire/master/install.sh)
+```
+
+Or clone the repo and run it locally:
+
+```bash
+./install.sh
+```
+
+By default the virtualenv is created at `~/.bonfire/venv`. Override this by setting `BONFIRE_VENV`:
+
+```bash
+BONFIRE_VENV=/opt/bonfire/venv bash install.sh
+```
+
+After installation, add the virtualenv to your PATH as instructed by the script's output.
+
+## Installing locally (manual)
 
 We'd recommend setting up a virtual environment for bonfire:
 

--- a/bonfire/output.py
+++ b/bonfire/output.py
@@ -401,7 +401,7 @@ def render_version(version):
     if _is_interactive():
         console.print(f"[bold cyan]bonfire[/bold cyan] version [success]{version}[/success]")
     else:
-        click_echo(f"bonfire version {version}")
+        click_echo(f"{version}")
 
 
 def click_echo(msg="", **kwargs):

--- a/bonfire/utils.py
+++ b/bonfire/utils.py
@@ -606,7 +606,7 @@ def _compare_version(pypi_version):
             f"(yours: {my_version}, available: {pypi_version})"
             "\n\n"
             "upgrade with:\n"
-            f"    pip install --upgrade {PKG_NAME}"
+            f"    {sys.executable} -m pip install --upgrade {PKG_NAME}"
             "\n"
         )
     else:

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VENV_DIR="${BONFIRE_VENV:-$HOME/.bonfire/venv}"
+MIN_PYTHON_MAJOR=3
+MIN_PYTHON_MINOR=10
+
+if [ -t 1 ]; then
+    BOLD=$'\033[1m'
+    DIM=$'\033[2m'
+    GREEN=$'\033[32m'
+    CYAN=$'\033[36m'
+    YELLOW=$'\033[33m'
+    RED=$'\033[31m'
+    RESET=$'\033[0m'
+else
+    BOLD="" DIM="" GREEN="" CYAN="" YELLOW="" RED="" RESET=""
+fi
+
+info()  { printf "${CYAN}=>${RESET} %s\n" "$*"; }
+ok()    { printf "${GREEN}=>${RESET} %s\n" "$*"; }
+warn()  { printf "${YELLOW}=>${RESET} %s\n" "$*" >&2; }
+err()   { printf "${RED}=>${RESET} %s\n" "$*" >&2; }
+
+find_python() {
+    for cmd in python3 python; do
+        if command -v "$cmd" > /dev/null 2>&1; then
+            if "$cmd" -c "import sys; sys.exit(0 if sys.version_info >= ($MIN_PYTHON_MAJOR, $MIN_PYTHON_MINOR) else 1)" 2>/dev/null; then
+                echo "$cmd"
+                return
+            fi
+        fi
+    done
+    echo ""
+}
+
+PYTHON=$(find_python)
+if [ -z "$PYTHON" ]; then
+    err "python >= ${MIN_PYTHON_MAJOR}.${MIN_PYTHON_MINOR} is required but not found"
+    exit 1
+fi
+
+PYTHON_VERSION=$("$PYTHON" -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}')")
+info "using python ${BOLD}${PYTHON_VERSION}${RESET} ${DIM}($(command -v "$PYTHON"))${RESET}"
+
+info "creating virtualenv at ${BOLD}${VENV_DIR}${RESET} ..."
+mkdir -p "$(dirname "$VENV_DIR")"
+"$PYTHON" -m venv "$VENV_DIR"
+
+info "installing crc-bonfire ..."
+"${VENV_DIR}/bin/pip" install --upgrade pip --quiet
+"${VENV_DIR}/bin/pip" install --upgrade crc-bonfire --quiet
+
+BONFIRE_VERSION=$("${VENV_DIR}/bin/bonfire" version 2>/dev/null || echo "unknown")
+echo ""
+ok "${BOLD}bonfire ${BONFIRE_VERSION}${RESET} installed successfully!"
+echo ""
+echo -e "  add the following to your shell profile ${DIM}(~/.bashrc, ~/.zshrc, etc.)${RESET}:"
+echo ""
+echo -e "    ${YELLOW}export PATH=\"${VENV_DIR}/bin:\$PATH\"${RESET}"
+echo ""
+echo -e "  then restart your shell or run:"
+echo ""
+echo -e "    ${YELLOW}source ~/.bashrc${RESET}  ${DIM}# or ~/.zshrc${RESET}"
+echo ""


### PR DESCRIPTION
## Summary
- Add a standalone `install.sh` script that creates a virtualenv and installs bonfire from PyPI, with colored output and Python version detection
- Simplify the non-interactive `bonfire version` output to print only the version string (e.g. `1.2.3` instead of `bonfire version 1.2.3`), making it easier to use in scripts
- Fix the version upgrade prompt to use `sys.executable -m pip` instead of bare `pip`, ensuring the correct Python interpreter is used
- Remove the outdated Homebrew install section from the README (formula is pinned to v5.11.0, latest release is v6.16.0)
- Reorganize README: move GitHub token setup into its own section

## Test plan
- [x] Run `bash install.sh` on a clean system and verify bonfire installs correctly
- [x] Run `bonfire version` in a non-interactive context (e.g. piped) and confirm it outputs only the version number
- [x] Run `bonfire version` interactively and confirm the rich output still works
- [x] Trigger the version upgrade check and confirm the suggested command uses the full Python path

🤖 Generated with [Claude Code](https://claude.com/claude-code)