### PR TITLE
fix: remove duplicate --local parameter registration

### DIFF
--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -294,7 +294,6 @@ _ns_reserve_options = [
         default=None,
         help="Override the secret source namespace for the reservation (copies secrets from this namespace)",
     ),
-    _local_option,
 ]
 
 
@@ -877,6 +876,7 @@ def _list_namespaces(ctx, available, mine, output):
 
 @namespace.command("reserve")
 @options(_ns_reserve_options)
+@options([_local_option])
 @options(_timeout_options)
 @click.pass_context
 @click_exception_wrapper("namespace reserve")
@@ -1819,6 +1819,7 @@ def _cmd_process_iqe_cji(
 
 @main.command("deploy-iqe-cji")
 @options(_iqe_cji_process_options)
+@options([_local_option])
 @click.option(
     "--namespace",
     "-n",

--- a/bonfire/bonfire.py
+++ b/bonfire/bonfire.py
@@ -1819,7 +1819,6 @@ def _cmd_process_iqe_cji(
 
 @main.command("deploy-iqe-cji")
 @options(_iqe_cji_process_options)
-@options([_local_option])
 @click.option(
     "--namespace",
     "-n",


### PR DESCRIPTION
This PR removes the duplicate `_local_option` that was added to prevent warnings around `--local` being set twice upon invocation.

### Before
```
bonfire deploy rosa
12:17:01 WARNING  The parameter --local is used more than once. Remove its duplicate as parameters should be unique.
         WARNING  The parameter --local is used more than once. Remove its duplicate as parameters should be unique.
         INFO     reading config from: /Users/kysquizz/.config/bonfire/config.yaml
         INFO     expanding CLI alias 'rosa'
         INFO       alias sets target_env = rosa-ephemeral
         INFO       alias sets component_filter = ['rosa-ephemeral-cluster']
         INFO       alias sets pool = rosa
         INFO       alias sets timeout = 1800
         INFO       alias sets duration = 2h
         INFO     auto-resolving base namespace from target env 'rosa-ephemeral'
```

### After
```
bonfire deploy rosa
12:14:57 INFO     reading config from: /Users/kysquizz/.config/bonfire/config.yaml
         INFO     expanding CLI alias 'rosa'
         INFO       alias sets target_env = rosa-ephemeral
         INFO       alias sets component_filter = ['rosa-ephemeral-cluster']
         INFO       alias sets pool = rosa
         INFO       alias sets timeout = 1800
         INFO       alias sets duration = 2h
12:14:58 INFO     auto-resolving base namespace from target env 'rosa-ephemeral'
12:14:59 INFO     resolved base namespace 'rosa-ephemeral-base' for env 'rosa-ephemeral'
         INFO     setting base namespace 'rosa-ephemeral-base' associated with target env 'rosa-ephemeral'
```