### PR TITLE
Include unit tests against master branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - master
+  push:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,6 @@ jobs:
     - name: Checkout to master
       uses: actions/checkout@v6
 
-    - uses: chartboost/ruff-action@v1
-
     - name: Setup python
       uses: actions/setup-python@v6
       with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
   rev: v0.15.16
   hooks:
     # Run the linter.
-    - id: ruff
+    - id: ruff-check
       args: [ --fix ]
     # Run the formatter.
     - id: ruff-format

--- a/bonfire_lib/deploy.py
+++ b/bonfire_lib/deploy.py
@@ -56,23 +56,23 @@ def deploy_rosa(
 
     log.info(
         "deploying to namespace '%s' (env=%s, components=%s)",
-        namespace, target_env, component_filter,
+        namespace,
+        target_env,
+        component_filter,
     )
 
     apps_config = get_apps_for_env(
-        target_env, client=qontract_client,
+        target_env,
+        client=qontract_client,
     )
 
     if not apps_config:
-        raise FatalError(
-            f"no app configs found for env '{target_env}' in app-interface"
-        )
+        raise FatalError(f"no app configs found for env '{target_env}' in app-interface")
 
     components = _collect_components(apps_config, component_filter)
     if not components:
         raise FatalError(
-            f"no components matching filter {component_filter} "
-            f"found in env '{target_env}'"
+            f"no components matching filter {component_filter} found in env '{target_env}'"
         )
 
     all_resources = []
@@ -88,7 +88,8 @@ def deploy_rosa(
         processed_items = client.process_template(template, params, namespace=namespace)
         log.info(
             "component '%s' produced %d resources",
-            component["name"], len(processed_items),
+            component["name"],
+            len(processed_items),
         )
 
         all_resources.extend(processed_items)
@@ -98,7 +99,9 @@ def deploy_rosa(
 
     log.info(
         "applied %d resources to namespace '%s', waiting for readiness (timeout=%ds)",
-        len(applied), namespace, timeout,
+        len(applied),
+        namespace,
+        timeout,
     )
     wait_for_resources(client, namespace, timeout)
 
@@ -109,9 +112,7 @@ def deploy_rosa(
     }
 
 
-def _collect_components(
-    apps_config: dict, component_filter: list[str]
-) -> list[dict]:
+def _collect_components(apps_config: dict, component_filter: list[str]) -> list[dict]:
     """Flatten apps_config and filter to requested components."""
     components = []
     filter_set = set(component_filter) if component_filter else None
@@ -130,7 +131,11 @@ def _fetch_template(component: dict) -> tuple[str, bytes]:
     rf = RepoFile.from_component(component)
     log.debug(
         "component '%s': fetching template from %s/%s ref=%s path=%s",
-        component["name"], rf.org, rf.repo, rf.ref, rf.path,
+        component["name"],
+        rf.org,
+        rf.repo,
+        rf.ref,
+        rf.path,
     )
     return rf.fetch()
 
@@ -140,9 +145,7 @@ def _parse_template(component_name: str, content: bytes) -> dict:
     try:
         return yaml.safe_load(content)
     except Exception as err:
-        raise FatalError(
-            f"failed to parse template YAML for component '{component_name}': {err}"
-        )
+        raise FatalError(f"failed to parse template YAML for component '{component_name}': {err}")
 
 
 def _build_parameters(
@@ -182,9 +185,7 @@ def _apply_resources(
             result = client.apply_resource(resource, namespace=namespace)
             applied.append(result)
         except Exception as err:
-            raise FatalError(
-                f"failed to apply {kind}/{name} to namespace '{namespace}': {err}"
-            )
+            raise FatalError(f"failed to apply {kind}/{name} to namespace '{namespace}': {err}")
     return applied
 
 
@@ -211,8 +212,7 @@ def wait_for_resources(
         elapsed = time.time() - start
         if elapsed >= timeout:
             raise TimeoutError(
-                f"timed out after {timeout}s waiting for resources "
-                f"in namespace '{namespace}'"
+                f"timed out after {timeout}s waiting for resources in namespace '{namespace}'"
             )
 
         all_ready = True
@@ -268,7 +268,8 @@ def wait_for_resources(
         if not found_resources:
             log.debug(
                 "no resources found yet in namespace '%s' (%.0fs elapsed)",
-                namespace, elapsed,
+                namespace,
+                elapsed,
             )
 
         time.sleep(poll_interval)

--- a/bonfire_lib/k8s_client.py
+++ b/bonfire_lib/k8s_client.py
@@ -7,7 +7,6 @@ Supports three auth modes: explicit server+token, in-cluster, kubeconfig.
 import atexit
 import base64
 import copy
-import json
 import logging
 import os
 import tempfile

--- a/bonfire_lib/qontract.py
+++ b/bonfire_lib/qontract.py
@@ -100,13 +100,9 @@ class QontractClient:
         if token is None:
             token = os.getenv("QONTRACT_TOKEN")
         if username is None:
-            username = os.getenv(
-                "QONTRACT_USERNAME", os.getenv("APP_INTERFACE_USERNAME")
-            )
+            username = os.getenv("QONTRACT_USERNAME", os.getenv("APP_INTERFACE_USERNAME"))
         if password is None:
-            password = os.getenv(
-                "QONTRACT_PASSWORD", os.getenv("APP_INTERFACE_PASSWORD")
-            )
+            password = os.getenv("QONTRACT_PASSWORD", os.getenv("APP_INTERFACE_PASSWORD"))
 
         log.debug("qontract url: %s", base_url)
 
@@ -120,9 +116,7 @@ class QontractClient:
             transport_kwargs["auth"] = HTTPBasicAuth(username, password)
 
         transport = RequestsHTTPTransport(**transport_kwargs)
-        self._client = GQLClient(
-            transport=transport, fetch_schema_from_transport=False
-        )
+        self._client = GQLClient(transport=transport, fetch_schema_from_transport=False)
 
         logging.getLogger("gql").setLevel(logging.ERROR)
 
@@ -131,12 +125,9 @@ class QontractClient:
         for env_data in self._client.execute(ENVS_QUERY)["envs"]:
             if env_data["name"] == env_name:
                 raw_namespaces = env_data.get("namespaces") or []
-                env_data["namespaces"] = {
-                    ns["path"]: ns["name"] for ns in raw_namespaces
-                }
+                env_data["namespaces"] = {ns["path"]: ns["name"] for ns in raw_namespaces}
                 env_data["namespace_labels"] = {
-                    ns["path"]: _to_dict(ns.get("labels"))
-                    for ns in raw_namespaces
+                    ns["path"]: _to_dict(ns.get("labels")) for ns in raw_namespaces
                 }
                 return env_data
         raise ValueError(f"cannot find env '{env_name}'")
@@ -157,9 +148,7 @@ def _process_env_parameters(parameters):
             found = re.findall(r"\$\{([^$]+)\}", val)
             for var in found:
                 if var in parameters:
-                    parameters[key] = parameters[key].replace(
-                        "${" + var + "}", parameters[var]
-                    )
+                    parameters[key] = parameters[key].replace("${" + var + "}", parameters[var])
 
 
 def _check_replace_other(other_params, this_params, preferred_params):
@@ -167,9 +156,7 @@ def _check_replace_other(other_params, this_params, preferred_params):
     this_weight = 0
     other_weight = 0
 
-    preferred_params["CLOWDER_ENABLED"] = preferred_params.get(
-        "CLOWDER_ENABLED", "true"
-    )
+    preferred_params["CLOWDER_ENABLED"] = preferred_params.get("CLOWDER_ENABLED", "true")
 
     for param_name, param_value in preferred_params.items():
         if str(this_params.get(param_name)).lower() == str(param_value).lower():
@@ -202,16 +189,20 @@ def _add_component_if_priority_higher(
         apps[app_name]["components"].append(component)
     else:
         defined_multiple.add((app_name, component_name))
-        if _check_replace_other(
-            existing["parameters"], component["parameters"], preferred_params
-        ):
+        if _check_replace_other(existing["parameters"], component["parameters"], preferred_params):
             apps[app_name]["components"].remove(existing)
             apps[app_name]["components"].append(component)
 
 
 def _add_component(
-    apps, env, app_name, saas_file, resource_template, target,
-    defined_multiple, preferred_params,
+    apps,
+    env,
+    app_name,
+    saas_file,
+    resource_template,
+    target,
+    defined_multiple,
+    preferred_params,
 ):
     component_name = resource_template["name"]
 
@@ -230,7 +221,7 @@ def _add_component(
         repo_path = urlparse(url).path.strip("/")
         last_slash_pos = repo_path.rindex("/")
         org = repo_path[:last_slash_pos]
-        repo = repo_path[last_slash_pos + 1:]
+        repo = repo_path[last_slash_pos + 1 :]
     except (ValueError, IndexError) as err:
         raise ValueError(f"invalid repo url '{url}': {err}")
 
@@ -251,8 +242,12 @@ def _add_component(
     }
 
     _add_component_if_priority_higher(
-        apps, app_name, component_name, component,
-        defined_multiple, preferred_params,
+        apps,
+        app_name,
+        component_name,
+        component,
+        defined_multiple,
+        preferred_params,
     )
 
 
@@ -302,9 +297,14 @@ def get_apps_for_env(
                     if ns_path not in env.get("namespaces", {}):
                         continue
                     _add_component(
-                        apps, env, app["name"], saas_file,
-                        resource_template, target,
-                        defined_multiple, preferred_params,
+                        apps,
+                        env,
+                        app["name"],
+                        saas_file,
+                        resource_template,
+                        target,
+                        defined_multiple,
+                        preferred_params,
                     )
 
     if ignored_apps:

--- a/bonfire_lib/repo_fetch.py
+++ b/bonfire_lib/repo_fetch.py
@@ -12,7 +12,7 @@ import os
 import re
 import tempfile
 import time
-from urllib.parse import quote, urlparse
+from urllib.parse import quote
 from urllib.request import urlretrieve
 
 import requests
@@ -24,17 +24,11 @@ log = logging.getLogger(__name__)
 
 GH_RAW_URL = "https://raw.githubusercontent.com/{org}/{repo}/{ref}{path}"
 GH_API_URL = os.getenv("GITHUB_API_URL", "https://api.github.com")
-GH_BRANCH_URL = (
-    GH_API_URL.rstrip("/") + "/repos/{org}/{repo}/git/refs/heads/{branch}"
-)
+GH_BRANCH_URL = GH_API_URL.rstrip("/") + "/repos/{org}/{repo}/git/refs/heads/{branch}"
 
 GL_RAW_URL = "https://gitlab.cee.redhat.com/{group}/{project}/-/raw/{ref}{path}"
-GL_PROJECTS_URL = (
-    "https://gitlab.cee.redhat.com/api/v4/{type}/{group}/projects?search={name}"
-)
-GL_BRANCH_URL = (
-    "https://gitlab.cee.redhat.com/api/v4/projects/{id}/repository/branches/{branch}"
-)
+GL_PROJECTS_URL = "https://gitlab.cee.redhat.com/api/v4/{type}/{group}/projects?search={name}"
+GL_BRANCH_URL = "https://gitlab.cee.redhat.com/api/v4/projects/{id}/repository/branches/{branch}"
 
 GL_CA_CERT_URL = "https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem"
 
@@ -55,9 +49,7 @@ def _get_gl_ca_cert():
         atexit.register(os.unlink, _gl_ca_cert_path)
         return _gl_ca_cert_path
     except Exception as err:
-        raise FatalError(
-            f"Failed to download GitLab CA certificate from {GL_CA_CERT_URL}: {err}"
-        )
+        raise FatalError(f"Failed to download GitLab CA certificate from {GL_CA_CERT_URL}: {err}")
 
 
 class RepoFile:
@@ -89,21 +81,17 @@ class RepoFile:
         required_keys = ["host", "repo", "path"]
         missing = [k for k in required_keys if k not in component]
         if missing:
-            raise FatalError(
-                f"component config missing keys: {', '.join(missing)}"
-            )
+            raise FatalError(f"component config missing keys: {', '.join(missing)}")
 
         repo_str = component["repo"]
         host = component["host"]
 
         if host in ("github", "gitlab"):
             if "/" not in repo_str:
-                raise FatalError(
-                    f"invalid repo '{repo_str}', expected format: <org>/<repo>"
-                )
+                raise FatalError(f"invalid repo '{repo_str}', expected format: <org>/<repo>")
             last_slash = repo_str.rindex("/")
             org = repo_str[:last_slash]
-            repo = repo_str[last_slash + 1:]
+            repo = repo_str[last_slash + 1 :]
         else:
             raise FatalError(f"unsupported host '{host}'")
 
@@ -150,7 +138,8 @@ class RepoFile:
             else:
                 log.info(
                     "failed to fetch ref '%s' (http %d)",
-                    ref, response.status_code,
+                    ref,
+                    response.status_code,
                 )
                 if idx + 1 < len(refs_to_try):
                     continue
@@ -158,9 +147,7 @@ class RepoFile:
                 if self.ref in self._alternate_refs:
                     alts = ", ".join(self._alternate_refs[self.ref])
                     alts_txt = f" and alternates: {alts}"
-                raise FatalError(
-                    f"git ref fetch failed for '{self.ref}'{alts_txt}"
-                )
+                raise FatalError(f"git ref fetch failed for '{self.ref}'{alts_txt}")
 
         return response
 
@@ -173,28 +160,20 @@ class RepoFile:
         url = response.request.url
 
         if status_code == 429 or (
-            status_code == 403
-            and "api rate limit exceeded" in response.text.lower()
+            status_code == 403 and "api rate limit exceeded" in response.text.lower()
         ):
             if attempt == 3:
-                raise FatalError(
-                    f"GET {url} continues to hit rate limit after 3 attempts"
-                )
+                raise FatalError(f"GET {url} continues to hit rate limit after 3 attempts")
 
             if "retry-after" in response.headers:
                 sleep_seconds = int(response.headers["retry-after"])
             elif response.headers.get("x-ratelimit-remaining") == "0":
-                reset_time = (
-                    int(response.headers["x-ratelimit-reset"])
-                    or time.time() + 60
-                )
+                reset_time = int(response.headers["x-ratelimit-reset"]) or time.time() + 60
                 sleep_seconds = reset_time - time.time()
             else:
                 sleep_seconds = 60
 
-            log.warning(
-                "GET %s rate limited, retrying after %ds", url, sleep_seconds
-            )
+            log.warning("GET %s rate limited, retrying after %ds", url, sleep_seconds)
             time.sleep(sleep_seconds)
             kwargs["_attempt"] = attempt + 1
             return self._get(*args, **kwargs)
@@ -203,9 +182,7 @@ class RepoFile:
 
     def _get_gh_commit_hash(self):
         def get_ref_func(ref):
-            url = GH_BRANCH_URL.format(
-                org=self.org, repo=self.repo, branch=ref
-            )
+            url = GH_BRANCH_URL.format(org=self.org, repo=self.repo, branch=ref)
             return self._get(url, headers=self._gh_auth_headers)
 
         response = self._get_ref(get_ref_func)
@@ -219,28 +196,20 @@ class RepoFile:
         if not GIT_SHA_RE.match(commit):
             commit = self._get_gh_commit_hash()
 
-        url = GH_RAW_URL.format(
-            org=self.org, repo=self.repo, ref=commit, path=self.path
-        )
+        url = GH_RAW_URL.format(org=self.org, repo=self.repo, ref=commit, path=self.path)
         response = self._get(url, headers=self._gh_auth_headers)
         if response.status_code == 404:
-            raise FatalError(
-                f"template not found at {url} (http 404)"
-            )
+            raise FatalError(f"template not found at {url} (http 404)")
         response.raise_for_status()
         return commit, response.content
 
     def _get_gl_commit_hash(self):
         group, project = quote(self.org, safe=""), self.repo
-        url = GL_PROJECTS_URL.format(
-            type="groups", group=group, name=project
-        )
+        url = GL_PROJECTS_URL.format(type="groups", group=group, name=project)
         response = self._get(url, verify=self._gl_certfile)
         if response.status_code == 404:
             response = self._get(
-                GL_PROJECTS_URL.format(
-                    type="users", group=group, name=project
-                ),
+                GL_PROJECTS_URL.format(type="users", group=group, name=project),
                 verify=self._gl_certfile,
             )
         response.raise_for_status()
@@ -252,9 +221,7 @@ class RepoFile:
                 project_id = p["id"]
 
         if not project_id:
-            raise FatalError(
-                f"gitlab project ID not found for {self.org}/{self.repo}"
-            )
+            raise FatalError(f"gitlab project ID not found for {self.org}/{self.repo}")
 
         def get_ref_func(ref):
             return self._get(
@@ -270,13 +237,9 @@ class RepoFile:
         if not GIT_SHA_RE.match(commit):
             commit = self._get_gl_commit_hash()
 
-        url = GL_RAW_URL.format(
-            group=self.org, project=self.repo, ref=commit, path=self.path
-        )
+        url = GL_RAW_URL.format(group=self.org, project=self.repo, ref=commit, path=self.path)
         response = self._get(url, verify=self._gl_certfile)
         if response.status_code == 404:
-            raise FatalError(
-                f"template not found at {url} (http 404)"
-            )
+            raise FatalError(f"template not found at {url} (http 404)")
         response.raise_for_status()
         return commit, response.content

--- a/bonfire_mcp/server.py
+++ b/bonfire_mcp/server.py
@@ -332,7 +332,9 @@ async def _deploy_rosa(
         )
 
         describe_info = await asyncio.to_thread(
-            status.describe_namespace, client, namespace,
+            status.describe_namespace,
+            client,
+            namespace,
         )
 
         return {

--- a/tests/test_bonfire_lib/test_deploy.py
+++ b/tests/test_bonfire_lib/test_deploy.py
@@ -1,7 +1,7 @@
 """Tests for bonfire_lib.deploy module."""
 
 import pytest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 from bonfire_lib.deploy import (
     deploy_rosa,
@@ -51,9 +51,7 @@ class TestCollectComponents:
 class TestBuildParameters:
     def test_default_image_tag(self):
         component = {"parameters": {}, "hash_length": 7}
-        params = _build_parameters(
-            component, "abc1234567890", "my-ns", "env-my-ns"
-        )
+        params = _build_parameters(component, "abc1234567890", "my-ns", "env-my-ns")
         assert params["IMAGE_TAG"] == "abc1234"
         assert params["NAMESPACE"] == "my-ns"
         assert params["ENV_NAME"] == "env-my-ns"
@@ -70,41 +68,21 @@ class TestBuildParameters:
 
     def test_custom_hash_length(self):
         component = {"parameters": {}, "hash_length": 10}
-        params = _build_parameters(
-            component, "abc1234567890abcdef", "ns", "env-ns"
-        )
+        params = _build_parameters(component, "abc1234567890abcdef", "ns", "env-ns")
         assert params["IMAGE_TAG"] == "abc1234567"
 
 
 class TestIsCapiClusterReady:
     def test_ready_condition(self):
-        cluster = {
-            "status": {
-                "conditions": [
-                    {"type": "Ready", "status": "True"}
-                ]
-            }
-        }
+        cluster = {"status": {"conditions": [{"type": "Ready", "status": "True"}]}}
         assert _is_capi_cluster_ready(cluster) is True
 
     def test_available_condition(self):
-        cluster = {
-            "status": {
-                "conditions": [
-                    {"type": "Available", "status": "True"}
-                ]
-            }
-        }
+        cluster = {"status": {"conditions": [{"type": "Available", "status": "True"}]}}
         assert _is_capi_cluster_ready(cluster) is True
 
     def test_not_ready(self):
-        cluster = {
-            "status": {
-                "conditions": [
-                    {"type": "Ready", "status": "False"}
-                ]
-            }
-        }
+        cluster = {"status": {"conditions": [{"type": "Ready", "status": "False"}]}}
         assert _is_capi_cluster_ready(cluster) is False
 
     def test_no_conditions(self):
@@ -124,23 +102,11 @@ class TestIsCapiClusterReady:
 
 class TestIsClowdappReady:
     def test_ready_via_condition(self):
-        app = {
-            "status": {
-                "conditions": [
-                    {"type": "ReconciliationSuccessful", "status": "True"}
-                ]
-            }
-        }
+        app = {"status": {"conditions": [{"type": "ReconciliationSuccessful", "status": "True"}]}}
         assert _is_clowdapp_ready(app) is True
 
     def test_not_ready_via_condition(self):
-        app = {
-            "status": {
-                "conditions": [
-                    {"type": "ReconciliationSuccessful", "status": "False"}
-                ]
-            }
-        }
+        app = {"status": {"conditions": [{"type": "ReconciliationSuccessful", "status": "False"}]}}
         assert _is_clowdapp_ready(app) is False
 
     def test_ready_via_deployments(self):

--- a/tests/test_bonfire_lib/test_qontract.py
+++ b/tests/test_bonfire_lib/test_qontract.py
@@ -1,6 +1,5 @@
 """Tests for bonfire_lib.qontract module."""
 
-import pytest
 from unittest.mock import MagicMock, patch
 
 from bonfire_lib.qontract import (
@@ -61,7 +60,7 @@ class TestQontractClient:
     @patch("bonfire_lib.qontract.RequestsHTTPTransport")
     @patch("bonfire_lib.qontract.GQLClient")
     def test_init_with_token(self, mock_gql, mock_transport):
-        client = QontractClient(
+        QontractClient(
             base_url="https://example.com/graphql",
             token="Bearer mytoken",
         )
@@ -72,7 +71,7 @@ class TestQontractClient:
     @patch("bonfire_lib.qontract.RequestsHTTPTransport")
     @patch("bonfire_lib.qontract.GQLClient")
     def test_init_with_basic_auth(self, mock_gql, mock_transport):
-        client = QontractClient(
+        QontractClient(
             base_url="https://example.com/graphql",
             username="user",
             password="pass",
@@ -87,7 +86,7 @@ class TestQontractClient:
             "os.environ",
             {"QONTRACT_BASE_URL": "https://env.example.com/graphql"},
         ):
-            client = QontractClient()
+            QontractClient()
         call_kwargs = mock_transport.call_args
         assert call_kwargs[1]["url"] == "https://env.example.com/graphql"
 

--- a/tests/test_bonfire_lib/test_repo_fetch.py
+++ b/tests/test_bonfire_lib/test_repo_fetch.py
@@ -3,7 +3,7 @@
 import pytest
 from unittest.mock import MagicMock, patch
 
-from bonfire_lib.repo_fetch import RepoFile, GH_RAW_URL
+from bonfire_lib.repo_fetch import RepoFile
 from bonfire_lib.utils import FatalError
 
 
@@ -59,11 +59,13 @@ class TestFromComponent:
 
     def test_no_slash_in_repo_raises(self):
         with pytest.raises(FatalError, match="invalid repo"):
-            RepoFile.from_component({
-                "host": "github",
-                "repo": "noslash",
-                "path": "/t.yaml",
-            })
+            RepoFile.from_component(
+                {
+                    "host": "github",
+                    "repo": "noslash",
+                    "path": "/t.yaml",
+                }
+            )
 
     def test_default_ref(self):
         component = {
@@ -76,7 +78,9 @@ class TestFromComponent:
 
 
 class TestFetchGithub:
-    @patch.object(RepoFile, "_get_gh_commit_hash", return_value="abc1234567890abcdef1234567890abcdef123456")
+    @patch.object(
+        RepoFile, "_get_gh_commit_hash", return_value="abc1234567890abcdef1234567890abcdef123456"
+    )
     @patch.object(RepoFile, "_get")
     def test_branch_ref_resolves_commit(self, mock_get, mock_hash):
         rf = RepoFile("github", "org", "repo", "/template.yaml", "main")

--- a/tests/test_bonfire_mcp/test_server.py
+++ b/tests/test_bonfire_mcp/test_server.py
@@ -1,7 +1,7 @@
 """Tests for bonfire_mcp.server module — tool definitions and dispatch."""
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from bonfire_mcp.server import call_tool, list_tools, TOOLS
 from mcp.types import CallToolResult
@@ -374,6 +374,7 @@ class TestDeployRosa:
             mock_reservations.reserve.return_value = reservation_result
             with patch("bonfire_mcp.server.deploy") as mock_deploy:
                 from bonfire_lib.utils import FatalError as _FE
+
                 mock_deploy.deploy_rosa.side_effect = _FE("deploy failed")
                 result = await call_tool(
                     "ephemeral_deploy_rosa",


### PR DESCRIPTION
## Note
I opened this to run tests because I suspected they would fail in CI due to the mcp extra removal, which was proven correct.
I think the mcp tests are going to fail in the github workflow on master branch since the extra was removed - #602 

This PR:
- starts running tests against master
- drop deprecated/archived ruffcheck, pre-commit already used
- passes pre-commit in `build` job
- updates the alias name for pre-commit ruff-check
- make some pre-commit related auto-fixes

This PR does NOT:
- Fix unit test failures, see #602 
- update ruff to v16, see #600 

Suspicion is correct, failures here are from the CI pipeline running in github.
<details> 
_____________ ERROR collecting tests/test_bonfire_mcp/test_auth.py _____________
ImportError while importing test module '/home/runner/work/bonfire/bonfire/tests/test_bonfire_mcp/test_auth.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.11.16/x64/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/test_bonfire_mcp/test_auth.py:8: in <module>
    from bonfire_mcp.auth import load_k8s_client, _preflight_check
E   ModuleNotFoundError: No module named 'bonfire_mcp'
__________ ERROR collecting tests/test_bonfire_mcp/test_formatters.py __________
ImportError while importing test module '/home/runner/work/bonfire/bonfire/tests/test_bonfire_mcp/test_formatters.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.11.16/x64/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/test_bonfire_mcp/test_formatters.py:3: in <module>
    from bonfire_mcp.formatters import (
E   ModuleNotFoundError: No module named 'bonfire_mcp'
____________ ERROR collecting tests/test_bonfire_mcp/test_server.py ____________
ImportError while importing test module '/home/runner/work/bonfire/bonfire/tests/test_bonfire_mcp/test_server.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.11.16/x64/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/test_bonfire_mcp/test_server.py:6: in <module>
    from bonfire_mcp.server import call_tool, list_tools, TOOLS
E   ModuleNotFoundError: No module named 'bonfire_mcp'
</details>

Going to include additional commits to resolve the mcp test failures too.